### PR TITLE
Tag query change

### DIFF
--- a/paperless.go
+++ b/paperless.go
@@ -112,7 +112,6 @@ func (c *PaperlessClient) GetDocumentsByTags(ctx context.Context, tags []string)
 	}
 	searchQuery := strings.Join(tagQueries, "&")
 	path := fmt.Sprintf("api/documents/?%s", urlEncode(searchQuery))
-        log.Printf("Get URL: %s", path)
 
 	resp, err := c.Do(ctx, "GET", path, nil)
 	if err != nil {

--- a/paperless.go
+++ b/paperless.go
@@ -108,10 +108,11 @@ func (c *PaperlessClient) GetAllTags(ctx context.Context) (map[string]int, error
 func (c *PaperlessClient) GetDocumentsByTags(ctx context.Context, tags []string) ([]Document, error) {
 	tagQueries := make([]string, len(tags))
 	for i, tag := range tags {
-		tagQueries[i] = fmt.Sprintf("tag:%s", tag)
+		tagQueries[i] = fmt.Sprintf("tags__name__iexact=%s", tag)
 	}
-	searchQuery := strings.Join(tagQueries, " ")
-	path := fmt.Sprintf("api/documents/?query=%s", urlEncode(searchQuery))
+	searchQuery := strings.Join(tagQueries, "&")
+	path := fmt.Sprintf("api/documents/?%s", urlEncode(searchQuery))
+        log.Printf("Get URL: %s", path)
 
 	resp, err := c.Do(ctx, "GET", path, nil)
 	if err != nil {

--- a/paperless_test.go
+++ b/paperless_test.go
@@ -203,7 +203,7 @@ func TestGetDocumentsByTags(t *testing.T) {
 	// Set mock responses
 	env.setMockResponse("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
 		// Verify query parameters
-		expectedQuery := "query=tag:tag1+tag:tag2"
+		expectedQuery := "tags__name__iexact=tag1&tags__name__iexact=tag2"
 		assert.Equal(t, expectedQuery, r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(documentsResponse)


### PR DESCRIPTION
Hey, first of all - amazing work, thanks so much, love this repo and it was exactly what I was looking for when moving to Paperless-ngx. And some of the stuff being developed looks great too.

When querying documents from PL, it doesn't perform correctly when using 'api/documents/?query=tags:paperless-gpt' or 'api/documents/?query=tags:paperless-gpt-auto'. It returns 0 results. 

Paperless Version (docker:latest): 2.13.5

Scenario:
- Querying tags sometimes works when PL has just started
- When querying documents that are automatically tagged using workflow this does not work
- When querying document manually also does not work
- When you manually tag a document with 'paperless-gpt' or 'paperless-gpt-auto' it sometimes works
- So, in total, automatic tagging does not work

When I started diagnosing, I used the 'Filters' button at the top of the '/api/documents' and this gives a different query to use. Specifically 'api/documents/?tags__name__iexact=<insert_tag_here>' - note, no 'query=' or 'tags:' and since this change, this has worked as expected.

Hope this works as expected for you as well.

Thanks, Chris