### PR TITLE
make listen interface configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ services:
       VISION_LLM_PROVIDER: 'ollama' # Optional (for OCR) - ollama or openai
       VISION_LLM_MODEL: 'minicpm-v' # Optional (for OCR) - minicpm-v, for example for ollama, gpt-4o for openai
       LOG_LEVEL: 'info' # Optional or 'debug', 'warn', 'error'
+      LISTEN_INTERFACE: '127.0.0.1:8080' # Optional, default is ':8080'
     volumes:
       - ./prompts:/app/prompts # Mount the prompts directory
     ports:
@@ -147,6 +148,7 @@ If you prefer to run the application manually:
 | `VISION_LLM_PROVIDER` | The vision LLM provider to use for OCR (`openai` or `ollama`).                                                                                            | No       |
 | `VISION_LLM_MODEL`    | The model name to use for OCR (e.g., `minicpm-v`).                                                                                                        | No       |
 | `LOG_LEVEL`           | The log level for the application (`info`, `debug`, `warn`, `error`). Default is `info`.                                                                  | No       |
+| `LISTEN_INTERFACE`    | The interface paperless-gpt listens to. Default is `:8080`                                                                                                | No       |
 
 **Note:** When using Ollama, ensure that the Ollama server is running and accessible from the paperless-gpt container.
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ var (
 	visionLlmProvider = os.Getenv("VISION_LLM_PROVIDER")
 	visionLlmModel    = os.Getenv("VISION_LLM_MODEL")
 	logLevel          = strings.ToLower(os.Getenv("LOG_LEVEL"))
+	listenInterface   = os.Getenv("LISTEN_INTERFACE")
 
 	// Templates
 	titleTemplate *template.Template
@@ -200,8 +201,11 @@ func main() {
 	numWorkers := 1 // Number of workers to start
 	startWorkerPool(app, numWorkers)
 
-	log.Infoln("Server started on port :8080")
-	if err := router.Run(":8080"); err != nil {
+	if listenInterface == "" {
+		listenInterface = ":8080"
+	}
+	log.Infoln("Server started on interface", listenInterface)
+	if err := router.Run(listenInterface); err != nil {
 		log.Fatalf("Failed to run server: %v", err)
 	}
 }


### PR DESCRIPTION
This change allows to set the listen interface instead of hardcoding it to all interfaces at port 8080. 

This allows users to run paperless-gpt when port 8080 is already used or when a user has multiple interfaces (e.g. public and a private one) and needs to limit it to a specific one for security reasons. 

if no LISTEN_INTERFACE env var is set it falls back to :8080. So this change shouldn't lead to incompatibilities.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configurable network interface option for server deployment
	- Introduced `LISTEN_INTERFACE` environment variable to customize server listening address

- **Documentation**
	- Updated README with details about new environment variable configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->