### PR TITLE
Allow setting of path to read static files from

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ services:
       VISION_LLM_MODEL: 'minicpm-v' # Optional (for OCR) - minicpm-v, for example for ollama, gpt-4o for openai
       LOG_LEVEL: 'info' # Optional or 'debug', 'warn', 'error'
       LISTEN_INTERFACE: '127.0.0.1:8080' # Optional, default is ':8080'
+      WEBUI_PATH: '/usr/share/paperless-gpt/webui' # Optional, default is './web-app/dist'
     volumes:
       - ./prompts:/app/prompts # Mount the prompts directory
     ports:
@@ -149,6 +150,7 @@ If you prefer to run the application manually:
 | `VISION_LLM_MODEL`    | The model name to use for OCR (e.g., `minicpm-v`).                                                                                                        | No       |
 | `LOG_LEVEL`           | The log level for the application (`info`, `debug`, `warn`, `error`). Default is `info`.                                                                  | No       |
 | `LISTEN_INTERFACE`    | The interface paperless-gpt listens to. Default is `:8080`                                                                                                | No       |
+| `WEBUI_PATH`          | The path to load static content from. Default is `./web-app/dist`                                                                                         | No       |
 
 **Note:** When using Ollama, ensure that the Ollama server is running and accessible from the paperless-gpt container.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ services:
       VISION_LLM_PROVIDER: 'ollama' # Optional (for OCR) - ollama or openai
       VISION_LLM_MODEL: 'minicpm-v' # Optional (for OCR) - minicpm-v, for example for ollama, gpt-4o for openai
       LOG_LEVEL: 'info' # Optional or 'debug', 'warn', 'error'
+      LISTEN_INTERFACE: '127.0.0.1:8080' # Optional, default is ':8080'
     volumes:
       - ./prompts:/app/prompts # Mount the prompts directory
     ports:
@@ -147,6 +148,7 @@ If you prefer to run the application manually:
 | `VISION_LLM_PROVIDER` | The vision LLM provider to use for OCR (`openai` or `ollama`).                                                                                            | No       |
 | `VISION_LLM_MODEL`    | The model name to use for OCR (e.g., `minicpm-v`).                                                                                                        | No       |
 | `LOG_LEVEL`           | The log level for the application (`info`, `debug`, `warn`, `error`). Default is `info`.                                                                  | No       |
+| `LISTEN_INTERFACE`    | The interface paperless-gpt listens to. Default is `:8080`                                                                                                | No       |
 
 **Note:** When using Ollama, ensure that the Ollama server is running and accessible from the paperless-gpt container.
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ var (
 	visionLlmProvider = os.Getenv("VISION_LLM_PROVIDER")
 	visionLlmModel    = os.Getenv("VISION_LLM_MODEL")
 	logLevel          = strings.ToLower(os.Getenv("LOG_LEVEL"))
+	listenInterface   = os.Getenv("LISTEN_INTERFACE")
 
 	// Templates
 	titleTemplate *template.Template
@@ -200,8 +201,11 @@ func main() {
 	numWorkers := 1 // Number of workers to start
 	startWorkerPool(app, numWorkers)
 
-	log.Infoln("Server started on port :8080")
-	if err := router.Run(":8080"); err != nil {
+	if listenInterface == "" {
+		listenInterface = ":8080"
+	}
+	log.Infoln("Server started on interface", listenInterface)
+	if err := router.Run(listenInterface); err != nil {
 		log.Fatalf("Failed to run server: %v", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	visionLlmModel    = os.Getenv("VISION_LLM_MODEL")
 	logLevel          = strings.ToLower(os.Getenv("LOG_LEVEL"))
 	listenInterface   = os.Getenv("LISTEN_INTERFACE")
+	webuiPath         = os.Getenv("WEBUI_PATH")
 
 	// Templates
 	titleTemplate *template.Template
@@ -188,13 +189,16 @@ func main() {
 		})
 	}
 
+	if webuiPath == "" {
+		webuiPath = "./web-app/dist"
+	}
 	// Serve static files for the frontend under /assets
-	router.StaticFS("/assets", gin.Dir("./web-app/dist/assets", true))
-	router.StaticFile("/vite.svg", "./web-app/dist/vite.svg")
+	router.StaticFS("/assets", gin.Dir(webuiPath+"/assets", true))
+	router.StaticFile("/vite.svg", webuiPath+"/vite.svg")
 
 	// Catch-all route for serving the frontend
 	router.NoRoute(func(c *gin.Context) {
-		c.File("./web-app/dist/index.html")
+		c.File(webuiPath + "/index.html")
 	})
 
 	// Start OCR worker pool


### PR DESCRIPTION
Currently paperless-gpt relies on running from a specific current working directory. This works fine for docker and developer environments but is problematic behavior for running natively. 

This PR adds a new WEBUI_PATH setting, that can be used to serve static files from a specified directory (e.g. /usr/share/paperless-gpt/frontend).

This allows that static content can reside on a different path then usersettings (promps). Which is pretty important for being able to package this software for common linux distros that expect somewhat standardized paths. 

This PR is built ontop of my other PR: https://github.com/icereed/paperless-gpt/pull/57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configurable web UI path via `WEBUI_PATH` environment variable
	- Enhanced server listening interface configurability through `LISTEN_INTERFACE` environment variable

- **Documentation**
	- Updated README with details about new environment variables and their default values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->