### PR TITLE
feat: Setting to disabled auto generation of title or tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ If you prefer to run the application manually:
 | `VISION_LLM_MODEL`    | The model name to use for OCR (e.g., `minicpm-v`).                                                                                                        | No       |
 | `LOG_LEVEL`           | The log level for the application (`info`, `debug`, `warn`, `error`). Default is `info`.                                                                  | No       |
 | `LISTEN_INTERFACE`    | The interface paperless-gpt listens to. Default is `:8080`                                                                                                | No       |
+| `AUTO_GENERATE_TITLE` | Enable/disable title generation when automatically applying suggestions with `paperless-gpt-auto`. Default is `true`                                      | No       |
+| `AUTO_GENERATE_TAGS`  | Enable/disable tag generation when automatically applying suggestions with `paperless-gpt-auto`. Default is `true`                                        | No       |
 
 **Note:** When using Ollama, ensure that the Ollama server is running and accessible from the paperless-gpt container.
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ var (
 	visionLlmModel    = os.Getenv("VISION_LLM_MODEL")
 	logLevel          = strings.ToLower(os.Getenv("LOG_LEVEL"))
 	listenInterface   = os.Getenv("LISTEN_INTERFACE")
+	autoGenerateTitle = os.Getenv("AUTO_GENERATE_TITLE")
+	autoGenerateTags  = os.Getenv("AUTO_GENERATE_TAGS")
 
 	// Templates
 	titleTemplate *template.Template
@@ -283,8 +285,8 @@ func (app *App) processAutoTagDocuments() (int, error) {
 
 	suggestionRequest := GenerateSuggestionsRequest{
 		Documents:      documents,
-		GenerateTitles: true,
-		GenerateTags:   true,
+		GenerateTitles: strings.ToLower(autoGenerateTitle) != "false",
+		GenerateTags:   strings.ToLower(autoGenerateTags) != "false",
 	}
 
 	suggestions, err := app.generateDocumentSuggestions(ctx, suggestionRequest)


### PR DESCRIPTION
## Description

Two new environment variables to customize the behavior of `paperless-gpt-auto`. Both variables default to `true`.

```
AUTO_GENERATE_TITLE=true
AUTO_GENERATE_TAGS=true
```

## Motivation

For users who's scanners already title the documents or users who use paperless-ngx workflows to generate crafted titles. Use `AUTO_GENERATE_TITLE=false` to disable GPT title suggestions.

For users who leverage paperless-ngx's built-in automatic tag suggestions, or get undesirable results with GPT tagging, or want to save on GPT costs when tagging isn't needed. Use `AUTO_GENERATE_TAGS=false` to disable GPT tag suggestions and keep existing tags (except for `paperless-gpt-auto` which is always removed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options for automatic title and tag generation
  - New environment variables `AUTO_GENERATE_TITLE` and `AUTO_GENERATE_TAGS` allow users to control auto-processing behavior

- **Documentation**
  - Updated README with details about new environment variables and their default settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->