### PR TITLE
Revert "chore(deps): update golang docker tag to v1.23.5"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMMIT=unknown
 ARG BUILD_DATE=unknown
 
 # Stage 1: Build the Go binary
-FROM golang:1.23.5-alpine3.21 AS builder
+FROM golang:1.23.4-alpine3.21 AS builder
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
Reverts icereed/paperless-gpt#141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated base Docker image to use Go version 1.23.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->