### PR TITLE
Set Fixed Alpine Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN sed -i \
 RUN CGO_ENABLED=1 GOMAXPROCS=$(nproc) go build -tags musl -o paperless-gpt .
 
 # Stage 3: Create a lightweight image with just the binary
-FROM alpine:latest
+FROM alpine:3.21.2
 
 ENV GIN_MODE=release
 


### PR DESCRIPTION
The Dockerfile lacks reproducibility during the build process if the container images in use are not pinned to a specific version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the underlying system image to a fixed, stable version for enhanced runtime consistency.
  - Streamlined the installation of essential dependencies, improving secure connection handling and overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->