### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/paperless.go
+++ b/paperless.go
@@ -94,7 +94,6 @@ func (client *PaperlessClient) Do(ctx context.Context, method, path string, body
 	log.WithFields(logrus.Fields{
 		"method":  method,
 		"url":     url,
-		"headers": req.Header,
 	}).Debug("Making HTTP request")
 
 	resp, err := client.HTTPClient.Do(req)


### PR DESCRIPTION
Potential fix for [https://github.com/icereed/paperless-gpt/security/code-scanning/3](https://github.com/icereed/paperless-gpt/security/code-scanning/3)

To fix the problem, we should avoid logging sensitive information contained in HTTP headers. Instead of logging the entire headers, we can log only non-sensitive parts or obfuscate sensitive values. In this case, we will remove the logging of the headers entirely to ensure no sensitive information is exposed.

- Remove the logging of `req.Header` in the `logrus.Fields` on line 97.
- Ensure that the rest of the logging information remains intact to maintain the functionality of debugging non-sensitive parts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
