### PR TITLE
[fix for 311] CreatedDatePrompt to derive date when no day or month were p…

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ Document Content:
 {{.Content}}
 `
 	defaultCreatedDateTemplate = `I will provide you with the content of a document. Your task is to find the date when the document was created.
-Respond only with the date in YYYY-MM-DD format, without any additional information. If no date is found, respond with today's date.
+Respond only with the date in YYYY-MM-DD format, without any additional information. If no day was found, use the first day of the month. If no month was found, use January. If no date was found at all, answer with today's date.
 The content is likely in {{.Language}}. Today's date is {{.Today}}.
 
 Content:


### PR DESCRIPTION
fixes https://github.com/icereed/paperless-gpt/issues/311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the date extraction logic to handle incomplete dates. Now, if the day is missing, the first day of the month is used; if the month is missing, January is applied. When no valid date can be determined, today's date is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->