### PR TITLE
Refactor - Move background logic to background.go (and background_test.go)

### DIFF
--- a/background.go
+++ b/background.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Start our background jobs
+func (app *App) startBackgroundTasks() {
+	go func() {
+		minBackoffDuration := 10 * time.Second
+		maxBackoffDuration := time.Hour
+		pollingInterval := 10 * time.Second
+
+		backoffDuration := minBackoffDuration
+
+		for {
+			processedCount, err := func() (int, error) {
+				count := 0
+
+				// If OCR is enabled, run OCR tagging first
+				if app.isOcrEnabled() {
+					ocrCount, err := app.processAutoOcrTagDocuments()
+					if err != nil {
+						return 0, fmt.Errorf("error in processAutoOcrTagDocuments: %w", err)
+					}
+					count += ocrCount
+				}
+
+				// Run auto-tagging after OCR
+				autoCount, err := app.processAutoTagDocuments()
+				if err != nil {
+					return 0, fmt.Errorf("error in processAutoTagDocuments: %w", err)
+				}
+				count += autoCount
+
+				return count, nil
+			}()
+
+			if err != nil {
+				log.Errorf("Error in background tagging: %v", err)
+				time.Sleep(backoffDuration)
+
+				// Exponential backoff logic
+				backoffDuration *= 2
+				if backoffDuration > maxBackoffDuration {
+					log.Warnf("Max backoff duration reached. Using %v", maxBackoffDuration)
+					backoffDuration = maxBackoffDuration
+				}
+			} else {
+				// Reset backoff when processing succeeds
+				backoffDuration = minBackoffDuration
+			}
+
+			// If nothing was processed, pause before next cycle
+			if processedCount == 0 {
+				time.Sleep(pollingInterval)
+			}
+		}
+	}()
+}
+
+// processAutoTagDocuments handles the background auto-tagging of documents
+func (app *App) processAutoTagDocuments() (int, error) {
+	ctx := context.Background()
+
+	documents, err := app.Client.GetDocumentsByTags(ctx, []string{autoTag}, 25)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching documents with autoTag: %w", err)
+	}
+
+	if len(documents) == 0 {
+		log.Debugf("No documents with tag %s found", autoTag)
+		return 0, nil // No documents to process
+	}
+
+	log.Debugf("Found at least %d remaining documents with tag %s", len(documents), autoTag)
+
+	var errs []error
+	processedCount := 0
+
+	for _, document := range documents {
+		// Skip documents that have the autoOcrTag
+		if slices.Contains(document.Tags, autoOcrTag) {
+			log.Debugf("Skipping document %d as it has the OCR tag %s", document.ID, autoOcrTag)
+			continue
+		}
+
+		docLogger := documentLogger(document.ID)
+		docLogger.Info("Processing document for auto-tagging")
+
+		suggestionRequest := GenerateSuggestionsRequest{
+			Documents:              []Document{document},
+			GenerateTitles:         strings.ToLower(autoGenerateTitle) != "false",
+			GenerateTags:           strings.ToLower(autoGenerateTags) != "false",
+			GenerateCorrespondents: strings.ToLower(autoGenerateCorrespondents) != "false",
+			GenerateCreatedDate:    strings.ToLower(autoGenerateCreatedDate) != "false",
+		}
+
+		suggestions, err := app.generateDocumentSuggestions(ctx, suggestionRequest, docLogger)
+		if err != nil {
+			err = fmt.Errorf("error generating suggestions for document %d: %w", document.ID, err)
+			docLogger.Error(err.Error())
+			errs = append(errs, err)
+			continue
+		}
+
+		err = app.Client.UpdateDocuments(ctx, suggestions, app.Database, false)
+		if err != nil {
+			err = fmt.Errorf("error updating document %d: %w", document.ID, err)
+			docLogger.Error(err.Error())
+			errs = append(errs, err)
+			continue
+		}
+
+		docLogger.Info("Successfully processed document")
+		processedCount++
+	}
+
+	if len(errs) > 0 {
+		return processedCount, errors.Join(errs...)
+	}
+
+	return processedCount, nil
+}
+
+// processAutoOcrTagDocuments handles the background auto-tagging of OCR documents
+func (app *App) processAutoOcrTagDocuments() (int, error) {
+	ctx := context.Background()
+
+	documents, err := app.Client.GetDocumentsByTags(ctx, []string{autoOcrTag}, 25)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching documents with autoOcrTag: %w", err)
+	}
+
+	if len(documents) == 0 {
+		log.Debugf("No documents with tag %s found", autoOcrTag)
+		return 0, nil
+	}
+
+	log.Debugf("Found %d documents with tag %s", len(documents), autoOcrTag)
+
+	successCount := 0
+	var errs []error
+
+	for _, document := range documents {
+		docLogger := documentLogger(document.ID)
+		docLogger.Info("Processing document for OCR")
+
+		ocrContent, err := app.ProcessDocumentOCR(ctx, document.ID)
+		if err != nil {
+			docLogger.Errorf("OCR processing failed: %v", err)
+			errs = append(errs, fmt.Errorf("document %d OCR error: %w", document.ID, err))
+			continue
+		}
+		docLogger.Debug("OCR processing completed")
+
+		err = app.Client.UpdateDocuments(ctx, []DocumentSuggestion{
+			{
+				ID:               document.ID,
+				OriginalDocument: document,
+				SuggestedContent: ocrContent,
+				RemoveTags:       []string{autoOcrTag},
+			},
+		}, app.Database, false)
+		if err != nil {
+			docLogger.Errorf("Update after OCR failed: %v", err)
+			errs = append(errs, fmt.Errorf("document %d update error: %w", document.ID, err))
+			continue
+		}
+
+		docLogger.Info("Successfully processed document OCR")
+		successCount++
+	}
+
+	if len(errs) > 0 {
+		return successCount, fmt.Errorf("one or more errors occurred: %w", errors.Join(errs...))
+	}
+
+	return successCount, nil
+}

--- a/background.go
+++ b/background.go
@@ -16,7 +16,7 @@ type BackgroundProcessor interface {
 	isOcrEnabled() bool
 }
 
-// Start our background tasks in a thread
+// Start our background tasks in a goroutine
 func StartBackgroundTasks(ctx context.Context, app BackgroundProcessor) {
 	go func() {
 		minBackoffDuration := 10 * time.Second

--- a/background_test.go
+++ b/background_test.go
@@ -25,27 +25,6 @@ func (a *appStubBG) isOcrEnabled() bool                       { return true }
 func (a *appStubBG) processAutoOcrTagDocuments() (int, error) { a.ocrCalls++; return 0, nil }
 func (a *appStubBG) processAutoTagDocuments() (int, error)    { a.tagCalls++; return 0, nil }
 
-// Test that our Background-Tasks shutdown cleanly and process properly
-func TestBackgroundTasks_ShutdownOnContextCancel(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
-	defer cancel()
-
-	// init our stubbed app
-	app := &appStubBG{}
-
-	// start the background processing
-	StartBackgroundTasks(ctx, app)
-
-	// Wait for shutdown to occur
-	time.Sleep(250 * time.Millisecond)
-
-	assert.Greater(t, app.ocrCalls, 0, "OCR loop should have run at least once")
-	assert.Greater(t, app.tagCalls, 0, "Tag loop should have run at least once")
-
-	// If no panic or hang occurred, test is successful
-	t.Log("Background task exited cleanly")
-}
-
 // Setup a Test
 func setupTest(t *testing.T) *testEnv {
 	// Initialize templates
@@ -130,6 +109,27 @@ func setupTestCase(tc TestCase, env *testEnv) {
 			})
 		}
 	})
+}
+
+// Test that our Background-Tasks shutdown cleanly and process properly
+func TestBackgroundTasks_ShutdownOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	// init our stubbed app
+	app := &appStubBG{}
+
+	// start the background processing
+	StartBackgroundTasks(ctx, app)
+
+	// Wait for shutdown to occur
+	time.Sleep(250 * time.Millisecond)
+
+	assert.Greater(t, app.ocrCalls, 0, "OCR loop should have run at least once")
+	assert.Greater(t, app.tagCalls, 0, "Tag loop should have run at least once")
+
+	// If no panic or hang occurred, test is successful
+	t.Log("Background task exited cleanly")
 }
 
 // Test processAutoTagDocument (OCR tag is used to test skipping)

--- a/background_test.go
+++ b/background_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTest(t *testing.T) *testEnv {
+	// Initialize templates
+	var err error
+	titleTemplate, err = template.New("title").Funcs(sprig.FuncMap()).Parse("")
+	require.NoError(t, err)
+	tagTemplate, err = template.New("tag").Funcs(sprig.FuncMap()).Parse("")
+	require.NoError(t, err)
+	correspondentTemplate, err = template.New("correspondent").Funcs(sprig.FuncMap()).Parse("")
+	require.NoError(t, err)
+	createdDateTemplate, err = template.New("created_date").Funcs(sprig.FuncMap()).Parse("")
+	require.NoError(t, err)
+
+	// Create test environment
+	env := newTestEnv(t)
+
+	// Do not defer teardown here — caller must do it
+	return env
+}
+
+func setupTestCase(tc TestCase, env *testEnv) {
+	// Mock the GetAllTags response
+	env.setMockResponse("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"results": []map[string]interface{}{
+				{"id": 1, "name": autoTag},
+				{"id": 2, "name": autoOcrTag},
+				{"id": 3, "name": "other-tag"},
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+
+	// Mock the GetDocumentsByTags response
+	env.setMockResponse("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
+		response := GetDocumentsApiResponse{
+			Results: make([]GetDocumentApiResponseResult, len(tc.documents)),
+		}
+		for i, doc := range tc.documents {
+			tagIds := make([]int, len(doc.Tags))
+			for j, tagName := range doc.Tags {
+				switch tagName {
+				case autoTag:
+					tagIds[j] = 1
+				case autoOcrTag:
+					tagIds[j] = 2
+				default:
+					tagIds[j] = 3
+				}
+			}
+			response.Results[i] = GetDocumentApiResponseResult{
+				ID:          doc.ID,
+				Title:       doc.Title,
+				Tags:        tagIds,
+				Content:     "Test content",
+				CreatedDate: "1999-09-09",
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	})
+
+	// Mock the correspondent creation endpoint
+	env.setMockResponse("/api/correspondents/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			// Mock successful correspondent creation
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   3,
+				"name": "test response",
+			})
+		} else {
+			// Mock GET response for existing correspondents
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results": []map[string]interface{}{
+					{"id": 1, "name": "Alpha"},
+					{"id": 2, "name": "Beta"},
+				},
+			})
+		}
+	})
+}
+
+// Test processAutoTagDocument (OCR tag is used to test skipping)
+func TestProcessAutoTagDocuments(t *testing.T) {
+	// Initialize required global variables
+	autoTag = "paperless-gpt-auto"
+	autoOcrTag = "paperless-gpt-ocr-auto"
+
+	// Set up test cases
+	testCases := []TestCase{
+		{
+			name: "Skip document with autoOcrTag",
+			documents: []TestDocument{
+				{
+					ID:    1,
+					Title: "Doc with OCR tag",
+					Tags:  []string{autoTag, autoOcrTag},
+				},
+				{
+					ID:    2,
+					Title: "Doc without OCR tag",
+					Tags:  []string{autoTag},
+				},
+				{
+					ID:    3,
+					Title: "Doc with OCR tag",
+					Tags:  []string{autoTag, autoOcrTag},
+				},
+			},
+			expectedCount:  1,
+			updateResponse: http.StatusOK,
+		},
+		{
+			name:           "No documents to process",
+			documents:      []TestDocument{},
+			expectedCount:  0,
+			updateResponse: http.StatusOK,
+		},
+		{
+			name: "Two fail but continues processing on update failure",
+			documents: []TestDocument{
+				{ID: 7, Title: "Good One", Tags: []string{autoTag}},
+				{ID: 8, Title: "Update Fails 1", Tags: []string{autoTag}, FailUpdate: true},
+				{ID: 9, Title: "Good Two", Tags: []string{autoTag}},
+				{ID: 10, Title: "Update Fails 2", Tags: []string{autoTag}, FailUpdate: true},
+			},
+			expectedCount:  2,             // Only 7 and 9 succeed
+			expectedError:  "document 10", // error should mention at least one of the failed docs
+			updateResponse: http.StatusOK, // By default it should be OK
+		},
+	}
+
+	// Setup the Test
+	env := setupTest(t)
+	defer env.teardown()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Running Test-Case %s", tc.name)
+
+			// Setup the individual Test-Case
+			setupTestCase(tc, env)
+
+			// Create test app
+			app := &App{
+				Client:   env.client,
+				Database: env.db,
+				LLM:      &mockLLM{}, // Use mock LLM from app_llm_test.go
+			}
+
+			// Set auto-generate flags
+			autoGenerateTitle = "true"
+			autoGenerateTags = "true"
+			autoGenerateCorrespondents = "true"
+			autoGenerateCreatedDate = "true"
+
+			// Handle the invidual documents
+			for _, doc := range tc.documents {
+				updatePath := fmt.Sprintf("/api/documents/%d/", doc.ID)
+
+				// Wrap everything in a closure to safely capture values
+				func(docID int, docTitle string, failUpdate bool, updateStatus int) {
+					// PATCH /api/documents/{id}/
+					env.setMockResponse(updatePath, func(w http.ResponseWriter, r *http.Request) {
+
+						if failUpdate {
+							t.Logf("Simulating update failure for document %d", docID)
+							w.WriteHeader(http.StatusInternalServerError)
+							_ = json.NewEncoder(w).Encode(map[string]interface{}{
+								"detail": fmt.Sprintf("Simulated update failure for document %d", docID),
+							})
+							return
+						}
+
+						t.Logf("Simulating successful update for document %d", docID)
+						w.WriteHeader(updateStatus)
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{
+							"id":           docID,
+							"title":        "Updated " + docTitle,
+							"tags":         []int{1, 3},
+							"created_date": "1999-09-19",
+						})
+					})
+
+				}(doc.ID, doc.Title, doc.FailUpdate, tc.updateResponse)
+			}
+
+			// Test the processAutoTagDocuments method
+			count, err := app.processAutoTagDocuments()
+
+			// Verify results
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedCount, count)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"paperless-gpt/ocr"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -229,48 +226,8 @@ func main() {
 		}
 	}
 
-	// Start background process for auto-tagging
-	go func() {
-		minBackoffDuration := 10 * time.Second
-		maxBackoffDuration := time.Hour
-		pollingInterval := 10 * time.Second
-
-		backoffDuration := minBackoffDuration
-		for {
-			processedCount, err := func() (int, error) {
-				count := 0
-				if app.isOcrEnabled() {
-					ocrCount, err := app.processAutoOcrTagDocuments()
-					if err != nil {
-						return 0, fmt.Errorf("error in processAutoOcrTagDocuments: %w", err)
-					}
-					count += ocrCount
-				}
-				autoCount, err := app.processAutoTagDocuments()
-				if err != nil {
-					return 0, fmt.Errorf("error in processAutoTagDocuments: %w", err)
-				}
-				count += autoCount
-				return count, nil
-			}()
-
-			if err != nil {
-				log.Errorf("Error in processAutoTagDocuments: %v", err)
-				time.Sleep(backoffDuration)
-				backoffDuration *= 2 // Exponential backoff
-				if backoffDuration > maxBackoffDuration {
-					log.Warnf("Repeated errors in processAutoTagDocuments detected. Setting backoff to %v", maxBackoffDuration)
-					backoffDuration = maxBackoffDuration
-				}
-			} else {
-				backoffDuration = minBackoffDuration
-			}
-
-			if processedCount == 0 {
-				time.Sleep(pollingInterval)
-			}
-		}
-	}()
+	// Start background tasks for auto-tagging and auto-ocr
+	app.startBackgroundTasks()
 
 	// Create a Gin router with default middleware (logger and recovery)
 	router := gin.Default()
@@ -482,126 +439,6 @@ func validateOrDefaultEnvVars() {
 // documentLogger creates a logger with document context
 func documentLogger(documentID int) *logrus.Entry {
 	return log.WithField("document_id", documentID)
-}
-
-// processAutoTagDocuments handles the background auto-tagging of documents
-func (app *App) processAutoTagDocuments() (int, error) {
-	ctx := context.Background()
-
-	documents, err := app.Client.GetDocumentsByTags(ctx, []string{autoTag}, 25)
-	if err != nil {
-		return 0, fmt.Errorf("error fetching documents with autoTag: %w", err)
-	}
-
-	if len(documents) == 0 {
-		log.Debugf("No documents with tag %s found", autoTag)
-		return 0, nil // No documents to process
-	}
-
-	log.Debugf("Found at least %d remaining documents with tag %s", len(documents), autoTag)
-
-	var errs []error
-	processedCount := 0
-
-	for _, document := range documents {
-		// Skip documents that have the autoOcrTag
-		if slices.Contains(document.Tags, autoOcrTag) {
-			log.Debugf("Skipping document %d as it has the OCR tag %s", document.ID, autoOcrTag)
-			continue
-		}
-
-		docLogger := documentLogger(document.ID)
-		docLogger.Info("Processing document for auto-tagging")
-
-		suggestionRequest := GenerateSuggestionsRequest{
-			Documents:              []Document{document},
-			GenerateTitles:         strings.ToLower(autoGenerateTitle) != "false",
-			GenerateTags:           strings.ToLower(autoGenerateTags) != "false",
-			GenerateCorrespondents: strings.ToLower(autoGenerateCorrespondents) != "false",
-			GenerateCreatedDate:    strings.ToLower(autoGenerateCreatedDate) != "false",
-		}
-
-		suggestions, err := app.generateDocumentSuggestions(ctx, suggestionRequest, docLogger)
-		if err != nil {
-			err = fmt.Errorf("error generating suggestions for document %d: %w", document.ID, err)
-			docLogger.Error(err.Error())
-			errs = append(errs, err)
-			continue
-		}
-
-		err = app.Client.UpdateDocuments(ctx, suggestions, app.Database, false)
-		if err != nil {
-			err = fmt.Errorf("error updating document %d: %w", document.ID, err)
-			docLogger.Error(err.Error())
-			errs = append(errs, err)
-			continue
-		}
-
-		docLogger.Info("Successfully processed document")
-		processedCount++
-	}
-
-	if len(errs) > 0 {
-		return processedCount, errors.Join(errs...)
-	}
-
-	return processedCount, nil
-}
-
-// processAutoOcrTagDocuments handles the background auto-tagging of OCR documents
-func (app *App) processAutoOcrTagDocuments() (int, error) {
-	ctx := context.Background()
-
-	documents, err := app.Client.GetDocumentsByTags(ctx, []string{autoOcrTag}, 25)
-	if err != nil {
-		return 0, fmt.Errorf("error fetching documents with autoOcrTag: %w", err)
-	}
-
-	if len(documents) == 0 {
-		log.Debugf("No documents with tag %s found", autoOcrTag)
-		return 0, nil
-	}
-
-	log.Debugf("Found %d documents with tag %s", len(documents), autoOcrTag)
-
-	successCount := 0
-	var errs []error
-
-	for _, document := range documents {
-		docLogger := documentLogger(document.ID)
-		docLogger.Info("Processing document for OCR")
-
-		ocrContent, err := app.ProcessDocumentOCR(ctx, document.ID)
-		if err != nil {
-			docLogger.Errorf("OCR processing failed: %v", err)
-			errs = append(errs, fmt.Errorf("document %d OCR error: %w", document.ID, err))
-			continue
-		}
-		docLogger.Debug("OCR processing completed")
-
-		err = app.Client.UpdateDocuments(ctx, []DocumentSuggestion{
-			{
-				ID:               document.ID,
-				OriginalDocument: document,
-				SuggestedContent: ocrContent,
-				RemoveTags:       []string{autoOcrTag},
-			},
-		}, app.Database, false)
-		if err != nil {
-			docLogger.Errorf("Update after OCR failed: %v", err)
-			errs = append(errs, fmt.Errorf("document %d update error: %w", document.ID, err))
-			continue
-		}
-
-		docLogger.Info("Successfully processed document OCR")
-		successCount++
-	}
-
-	if len(errs) > 0 {
-		return successCount, fmt.Errorf("one or more errors occurred: %w", errors.Join(errs...))
-	}
-
-	return successCount, nil
 }
 
 // removeTagFromList removes a specific tag from a list of tags

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -134,6 +135,10 @@ type App struct {
 }
 
 func main() {
+	// Context for proper control of background-thread
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Validate Environment Variables
 	validateOrDefaultEnvVars()
 
@@ -226,8 +231,8 @@ func main() {
 		}
 	}
 
-	// Start background tasks for auto-tagging and auto-ocr
-	app.startBackgroundTasks()
+	// Start Background-Tasks for Auto-Tagging and Auto-OCR (if enabled)
+	StartBackgroundTasks(ctx, app)
 
 	// Create a Gin router with default middleware (logger and recovery)
 	router := gin.Default()

--- a/main_test.go
+++ b/main_test.go
@@ -1,19 +1,15 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"text/template"
-
-	"github.com/Masterminds/sprig/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// This is our Mocked TestDocument contain extra parameters for testing
 type TestDocument struct {
 	ID         int
 	Title      string
@@ -21,200 +17,16 @@ type TestDocument struct {
 	FailUpdate bool // simulate update failure
 }
 
-func TestProcessAutoTagDocuments(t *testing.T) {
-	// Initialize required global variables
-	autoTag = "paperless-gpt-auto"
-	autoOcrTag = "paperless-gpt-ocr-auto"
-
-	// Initialize templates
-	var err error
-	titleTemplate, err = template.New("title").Funcs(sprig.FuncMap()).Parse("")
-	require.NoError(t, err)
-	tagTemplate, err = template.New("tag").Funcs(sprig.FuncMap()).Parse("")
-	require.NoError(t, err)
-	correspondentTemplate, err = template.New("correspondent").Funcs(sprig.FuncMap()).Parse("")
-	require.NoError(t, err)
-	createdDateTemplate, err = template.New("created_date").Funcs(sprig.FuncMap()).Parse("")
-	require.NoError(t, err)
-
-	// Create test environment
-	env := newTestEnv(t)
-	defer env.teardown()
-
-	// Set up test cases
-	testCases := []struct {
-		name           string
-		documents      []TestDocument
-		expectedCount  int
-		expectedError  string
-		updateResponse int // HTTP status code for update response
-	}{
-		{
-			name: "Skip document with autoOcrTag",
-			documents: []TestDocument{
-				{
-					ID:    1,
-					Title: "Doc with OCR tag",
-					Tags:  []string{autoTag, autoOcrTag},
-				},
-				{
-					ID:    2,
-					Title: "Doc without OCR tag",
-					Tags:  []string{autoTag},
-				},
-				{
-					ID:    3,
-					Title: "Doc with OCR tag",
-					Tags:  []string{autoTag, autoOcrTag},
-				},
-			},
-			expectedCount:  1,
-			updateResponse: http.StatusOK,
-		},
-		{
-			name:           "No documents to process",
-			documents:      []TestDocument{},
-			expectedCount:  0,
-			updateResponse: http.StatusOK,
-		},
-		{
-			name: "Two fail but continues processing on update failure",
-			documents: []TestDocument{
-				{ID: 7, Title: "Good One", Tags: []string{autoTag}},
-				{ID: 8, Title: "Update Fails 1", Tags: []string{autoTag}, FailUpdate: true},
-				{ID: 9, Title: "Good Two", Tags: []string{autoTag}},
-				{ID: 10, Title: "Update Fails 2", Tags: []string{autoTag}, FailUpdate: true},
-			},
-			expectedCount:  2,             // Only 7 and 9 succeed
-			expectedError:  "document 10", // error should mention at least one of the failed docs
-			updateResponse: http.StatusOK, // By default it should be OK
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Logf("Running Test-Case %s", tc.name)
-			// Mock the GetAllTags response
-			env.setMockResponse("/api/tags/", func(w http.ResponseWriter, r *http.Request) {
-				response := map[string]interface{}{
-					"results": []map[string]interface{}{
-						{"id": 1, "name": autoTag},
-						{"id": 2, "name": autoOcrTag},
-						{"id": 3, "name": "other-tag"},
-					},
-				}
-				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(response)
-			})
-
-			// Mock the GetDocumentsByTags response
-			env.setMockResponse("/api/documents/", func(w http.ResponseWriter, r *http.Request) {
-				response := GetDocumentsApiResponse{
-					Results: make([]GetDocumentApiResponseResult, len(tc.documents)),
-				}
-				for i, doc := range tc.documents {
-					tagIds := make([]int, len(doc.Tags))
-					for j, tagName := range doc.Tags {
-						switch tagName {
-						case autoTag:
-							tagIds[j] = 1
-						case autoOcrTag:
-							tagIds[j] = 2
-						default:
-							tagIds[j] = 3
-						}
-					}
-					response.Results[i] = GetDocumentApiResponseResult{
-						ID:          doc.ID,
-						Title:       doc.Title,
-						Tags:        tagIds,
-						Content:     "Test content",
-						CreatedDate: "1999-09-09",
-					}
-				}
-				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(response)
-			})
-
-			// Mock the correspondent creation endpoint
-			env.setMockResponse("/api/correspondents/", func(w http.ResponseWriter, r *http.Request) {
-				if r.Method == "POST" {
-					// Mock successful correspondent creation
-					w.WriteHeader(http.StatusCreated)
-					json.NewEncoder(w).Encode(map[string]interface{}{
-						"id":   3,
-						"name": "test response",
-					})
-				} else {
-					// Mock GET response for existing correspondents
-					w.WriteHeader(http.StatusOK)
-					json.NewEncoder(w).Encode(map[string]interface{}{
-						"results": []map[string]interface{}{
-							{"id": 1, "name": "Alpha"},
-							{"id": 2, "name": "Beta"},
-						},
-					})
-				}
-			})
-
-			// Create test app
-			app := &App{
-				Client:   env.client,
-				Database: env.db,
-				LLM:      &mockLLM{}, // Use mock LLM from app_llm_test.go
-			}
-
-			// Set auto-generate flags
-			autoGenerateTitle = "true"
-			autoGenerateTags = "true"
-			autoGenerateCorrespondents = "true"
-			autoGenerateCreatedDate = "true"
-
-			// Handle the invidual documents
-			for _, doc := range tc.documents {
-				updatePath := fmt.Sprintf("/api/documents/%d/", doc.ID)
-
-				// Wrap everything in a closure to safely capture values
-				func(docID int, docTitle string, failUpdate bool, updateStatus int) {
-					// PATCH /api/documents/{id}/
-					env.setMockResponse(updatePath, func(w http.ResponseWriter, r *http.Request) {
-
-						if failUpdate {
-							t.Logf("Simulating update failure for document %d", docID)
-							w.WriteHeader(http.StatusInternalServerError)
-							_ = json.NewEncoder(w).Encode(map[string]interface{}{
-								"detail": fmt.Sprintf("Simulated update failure for document %d", docID),
-							})
-							return
-						}
-
-						t.Logf("Simulating successful update for document %d", docID)
-						w.WriteHeader(updateStatus)
-						_ = json.NewEncoder(w).Encode(map[string]interface{}{
-							"id":           docID,
-							"title":        "Updated " + docTitle,
-							"tags":         []int{1, 3},
-							"created_date": "1999-09-19",
-						})
-					})
-
-				}(doc.ID, doc.Title, doc.FailUpdate, tc.updateResponse)
-			}
-
-			count, err := app.processAutoTagDocuments()
-
-			// Verify results
-			if tc.expectedError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedCount, count)
-			}
-		})
-	}
+// Use this for TestCases in your tests
+type TestCase struct {
+	name           string
+	documents      []TestDocument
+	expectedCount  int
+	expectedError  string
+	updateResponse int // HTTP status code for update response
 }
 
+// Test our HTTP-Client
 func TestCreateCustomHTTPClient(t *testing.T) {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This is our Mocked TestDocument containing extra parameters for testing
+// TestDocument containing extra parameters for testing
 type TestDocument struct {
 	ID         int
 	Title      string

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This is our Mocked TestDocument contain extra parameters for testing
+// This is our Mocked TestDocument containing extra parameters for testing
 type TestDocument struct {
 	ID         int
 	Title      string


### PR DESCRIPTION
**What this does:**

- create `background.go` and `background_test.go`
- in `background.go`: add `StartBackgroundTasks(ctx, app)` (with interface for testing) - gets called in `main.go` line 230 instead of existing anonymous and embedded coroutine in `main()`
- from `main.go` move `processAutoTagDocuments` and `processAutoOcrTagDocuments` to `background.go`
- from `main_test.go` move `TestProcessAutoTagDocuments` to `background_test.go`
- in `main_test.go` - add `TestCase` for general typing of Test Cases
- in `background_test.go` move re-usable setups to `setupTest` and `setupTestCases`
- test control loop for proper exit

**Detailed Write-Up:**

This is basically a cleanup / refactoring PR which moves the background-specific stuff to their separate files and prepares for re-usable tests in `background_test.go` - maybe another test-case for `TestProcessAutoOCRTagDocuments`.

It makes the background-processes much more visible and separated and easier for new contributors to get an idea where they are living in and prepares for further improvements to the background-processing logic further on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a background processing system that automates document tagging and OCR extraction.

- **Refactor**
  - Streamlined the background task management for improved reliability and control over processing.

- **Tests**
  - Added new unit tests to validate background processing tasks and their shutdown behavior.
  - Simplified test case structure for document processing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->