### PR TITLE
adding docling with vlm pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://github.com/user-attachments/assets/bd5d38b9-9309-40b9-93ca-918dfa4f3fd4
    - **LLM OCR**: Use OpenAI or Ollama to extract text from images.
    - **Google Document AI**: Leverage Google's powerful Document AI for OCR tasks.
    - **Azure Document Intelligence**: Use Microsoft's enterprise OCR solution.
+   - **Docling Server**: Self-hosted OCR and document conversion service
 
 3. **Automatic Title, Tag & Created Date Generation**  
    No more guesswork. Let the AI do the naming and categorizing. You can easily review suggestions and refine them if needed.
@@ -64,6 +65,7 @@ https://github.com/user-attachments/assets/bd5d38b9-9309-40b9-93ca-918dfa4f3fd4
   - [LLM-based OCR](#1-llm-based-ocr-default)
   - [Azure Document Intelligence](#2-azure-document-intelligence)
   - [Google Document AI](#3-google-document-ai)
+  - [Docling Server](#4-docling-server)
   - [Comparing OCR Providers](#comparing-ocr-providers)
   - [Choosing the Right Provider](#choosing-the-right-provider)
 - [Configuration](#configuration)
@@ -144,6 +146,10 @@ services:
       # AZURE_DOCAI_OUTPUT_CONTENT_FORMAT: 'text' # Optional, defaults to 'text', other valid option is 'markdown'
               # 'markdown' requires the 'prebuilt-layout' model
 
+      # Option 4: Docling Server
+      # OCR_PROVIDER: 'docling'              # Use a Docling server
+      # DOCLING_URL: 'http://your-docling-server:port' # URL of your Docling instance
+
       AUTO_OCR_TAG: "paperless-gpt-ocr-auto" # Optional, default: paperless-gpt-ocr-auto
       OCR_LIMIT_PAGES: "5" # Optional, default: 5. Set to 0 for no limit.
       LOG_LEVEL: "info" # Optional: debug, warn, error
@@ -194,7 +200,7 @@ services:
 ---
 ## OCR Providers
 
-paperless-gpt supports three different OCR providers, each with unique strengths and capabilities:
+paperless-gpt supports four different OCR providers, each with unique strengths and capabilities:
 
 ### 1. LLM-based OCR (Default)
 - **Key Features**:
@@ -257,6 +263,22 @@ paperless-gpt supports three different OCR providers, each with unique strengths
   OCR_HOCR_OUTPUT_PATH: "/app/hocr" # Optional, default path
   ```
 
+### 4. Docling Server
+- **Key Features**:
+  - Self-hosted OCR and document conversion service
+  - Supports various input and output formats (including text)
+  - Utilizes multiple OCR engines (EasyOCR, Tesseract, etc.)
+  - Can be run locally or in a private network
+- **Best For**:
+  - Users who prefer a self-hosted solution
+  - Environments where data privacy is paramount
+  - Processing a wide variety of document types
+- **Configuration**:
+  ```yaml
+  OCR_PROVIDER: "docling"
+  DOCLING_URL: "http://your-docling-server:port"
+  ```
+
 ## Configuration
 
 ### Environment Variables
@@ -288,6 +310,7 @@ paperless-gpt supports three different OCR providers, each with unique strengths
 | `GOOGLE_LOCATION`                | Google Cloud region (e.g. `us`, `eu`). Required if OCR_PROVIDER is `google_docai`.                               | Cond.    |                        |
 | `GOOGLE_PROCESSOR_ID`            | Document AI processor ID. Required if OCR_PROVIDER is `google_docai`.                                            | Cond.    |                        |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to the mounted Google service account key. Required if OCR_PROVIDER is `google_docai`.                      | Cond.    |                        |
+| `DOCLING_URL`                    | URL of the Docling server instance. Required if OCR_PROVIDER is `docling`.                                        | Cond.    |                        |
 | `AUTO_OCR_TAG`                   | Tag for automatically processing docs with OCR.                                                                  | No       | paperless-gpt-ocr-auto |
 | `LOG_LEVEL`                      | Application log level (`info`, `debug`, `warn`, `error`).                                                        | No       | info                   |
 | `LISTEN_INTERFACE`               | Network interface to listen on.                                                                                  | No       | 8080                   |

--- a/main.go
+++ b/main.go
@@ -32,34 +32,35 @@ var (
 	log = logrus.New()
 
 	// Environment Variables
-	paperlessInsecureSkipVerify   = os.Getenv("PAPERLESS_INSECURE_SKIP_VERIFY") == "true"
-	correspondentBlackList        = strings.Split(os.Getenv("CORRESPONDENT_BLACK_LIST"), ",")
-	paperlessBaseURL              = os.Getenv("PAPERLESS_BASE_URL")
-	paperlessAPIToken             = os.Getenv("PAPERLESS_API_TOKEN")
-	azureDocAIEndpoint            = os.Getenv("AZURE_DOCAI_ENDPOINT")
-	azureDocAIKey                 = os.Getenv("AZURE_DOCAI_KEY")
-	azureDocAIModelID             = os.Getenv("AZURE_DOCAI_MODEL_ID")
-	azureDocAITimeout             = os.Getenv("AZURE_DOCAI_TIMEOUT_SECONDS")
-	AzureDocAIOutputContentFormat = os.Getenv("AZURE_DOCAI_OUTPUT_CONTENT_FORMAT")
-	openaiAPIKey                  = os.Getenv("OPENAI_API_KEY")
-	manualTag                     = os.Getenv("MANUAL_TAG")
-	autoTag                       = os.Getenv("AUTO_TAG")
-	manualOcrTag                  = os.Getenv("MANUAL_OCR_TAG") // Not used yet
-	autoOcrTag                    = os.Getenv("AUTO_OCR_TAG")
-	llmProvider                   = os.Getenv("LLM_PROVIDER")
-	llmModel                      = os.Getenv("LLM_MODEL")
-	visionLlmProvider             = os.Getenv("VISION_LLM_PROVIDER")
-	visionLlmModel                = os.Getenv("VISION_LLM_MODEL")
-	logLevel                      = strings.ToLower(os.Getenv("LOG_LEVEL"))
-	listenInterface               = os.Getenv("LISTEN_INTERFACE")
-	autoGenerateTitle             = os.Getenv("AUTO_GENERATE_TITLE")
-	autoGenerateTags              = os.Getenv("AUTO_GENERATE_TAGS")
-	autoGenerateCorrespondents    = os.Getenv("AUTO_GENERATE_CORRESPONDENTS")
-	autoGenerateCreatedDate       = os.Getenv("AUTO_GENERATE_CREATED_DATE")
-	limitOcrPages                 int // Will be read from OCR_LIMIT_PAGES
-	tokenLimit                    = 0 // Will be read from TOKEN_LIMIT
+	paperlessInsecureSkipVerify = os.Getenv("PAPERLESS_INSECURE_SKIP_VERIFY") == "true"
+	correspondentBlackList      = strings.Split(os.Getenv("CORRESPONDENT_BLACK_LIST"), ",")
+	paperlessBaseURL            = os.Getenv("PAPERLESS_BASE_URL")
+	paperlessAPIToken           = os.Getenv("PAPERLESS_API_TOKEN")
+	azureDocAIEndpoint          = os.Getenv("AZURE_DOCAI_ENDPOINT")
+	azureDocAIKey               = os.Getenv("AZURE_DOCAI_KEY")
+	azureDocAIModelID           = os.Getenv("AZURE_DOCAI_MODEL_ID")
+	azureDocAITimeout           = os.Getenv("AZURE_DOCAI_TIMEOUT_SECONDS")
+	openaiAPIKey                = os.Getenv("OPENAI_API_KEY")
+	manualTag                   = os.Getenv("MANUAL_TAG")
+	autoTag                     = os.Getenv("AUTO_TAG")
+	manualOcrTag                = os.Getenv("MANUAL_OCR_TAG") // Not used yet
+	autoOcrTag                  = os.Getenv("AUTO_OCR_TAG")
+	llmProvider                 = os.Getenv("LLM_PROVIDER")
+	llmModel                    = os.Getenv("LLM_MODEL")
+	visionLlmProvider           = os.Getenv("VISION_LLM_PROVIDER")
+	visionLlmModel              = os.Getenv("VISION_LLM_MODEL")
+	logLevel                    = strings.ToLower(os.Getenv("LOG_LEVEL"))
+	listenInterface             = os.Getenv("LISTEN_INTERFACE")
+	autoGenerateTitle           = os.Getenv("AUTO_GENERATE_TITLE")
+	autoGenerateTags            = os.Getenv("AUTO_GENERATE_TAGS")
+	autoGenerateCorrespondents  = os.Getenv("AUTO_GENERATE_CORRESPONDENTS")
+	autoGenerateCreatedDate     = os.Getenv("AUTO_GENERATE_CREATED_DATE")
+	limitOcrPages               int // Will be read from OCR_LIMIT_PAGES
+	tokenLimit                  = 0 // Will be read from TOKEN_LIMIT
 	ocrEnableHOCR                 = os.Getenv("OCR_ENABLE_HOCR") == "true"
 	ocrHOCROutputPath             = os.Getenv("OCR_HOCR_OUTPUT_PATH")
+	doclingURL                  = os.Getenv("DOCLING_URL")
+	doclingImageExportMode      = os.Getenv("DOCLING_IMAGE_EXPORT_MODE")
 
 	// Templates
 	titleTemplate         *template.Template
@@ -192,18 +193,20 @@ func main() {
 	ocrPrompt := promptBuffer.String()
 
 	ocrConfig := ocr.Config{
-		Provider:                 providerType,
-		GoogleProjectID:          os.Getenv("GOOGLE_PROJECT_ID"),
-		GoogleLocation:           os.Getenv("GOOGLE_LOCATION"),
-		GoogleProcessorID:        os.Getenv("GOOGLE_PROCESSOR_ID"),
-		VisionLLMProvider:        visionLlmProvider,
-		VisionLLMModel:           visionLlmModel,
-		VisionLLMPrompt:          ocrPrompt,
-		AzureEndpoint:            azureDocAIEndpoint,
-		AzureAPIKey:              azureDocAIKey,
-		AzureModelID:             azureDocAIModelID,
+		Provider:          providerType,
+		GoogleProjectID:   os.Getenv("GOOGLE_PROJECT_ID"),
+		GoogleLocation:    os.Getenv("GOOGLE_LOCATION"),
+		GoogleProcessorID: os.Getenv("GOOGLE_PROCESSOR_ID"),
+		VisionLLMProvider: visionLlmProvider,
+		VisionLLMModel:    visionLlmModel,
+		VisionLLMPrompt:   ocrPrompt,
+		AzureEndpoint:     azureDocAIEndpoint,
+		AzureAPIKey:       azureDocAIKey,
+		AzureModelID:      azureDocAIModelID,
 		AzureOutputContentFormat: AzureDocAIOutputContentFormat,
 		EnableHOCR:               ocrEnableHOCR,
+		DoclingURL:        doclingURL,
+		DoclingImageExportMode: doclingImageExportMode,
 	}
 
 	// Parse Azure timeout if set
@@ -434,6 +437,16 @@ func validateOrDefaultEnvVars() {
 		}
 		if azureDocAIKey == "" {
 			log.Fatal("Please set the AZURE_DOCAI_KEY environment variable for Azure provider")
+		}
+	}
+
+	if ocrProvider == "docling" {
+		if doclingURL == "" {
+			log.Fatal("Please set the DOCLING_URL environment variable for Docling provider")
+		}
+		if doclingImageExportMode == "" {
+			doclingImageExportMode = "embedded" // Default to PNG
+			log.Infof("DOCLING_IMAGE_EXPORT_MODE not set, defaulting to %s", doclingImageExportMode)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	azureDocAIKey               = os.Getenv("AZURE_DOCAI_KEY")
 	azureDocAIModelID           = os.Getenv("AZURE_DOCAI_MODEL_ID")
 	azureDocAITimeout           = os.Getenv("AZURE_DOCAI_TIMEOUT_SECONDS")
+	AzureDocAIOutputContentFormat = os.Getenv("AZURE_DOCAI_OUTPUT_CONTENT_FORMAT")
 	openaiAPIKey                = os.Getenv("OPENAI_API_KEY")
 	manualTag                   = os.Getenv("MANUAL_TAG")
 	autoTag                     = os.Getenv("AUTO_TAG")

--- a/ocr/docling_provider.go
+++ b/ocr/docling_provider.go
@@ -1,0 +1,173 @@
+package ocr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/sirupsen/logrus"
+)
+
+// DoclingProvider implements OCR using a Docling server
+type DoclingProvider struct {
+	baseURL    string
+	imageExportMode string
+	httpClient *retryablehttp.Client
+}
+
+// newDoclingProvider creates a new Docling OCR provider
+func newDoclingProvider(config Config) (*DoclingProvider, error) {
+	logger := log.WithFields(logrus.Fields{
+		"url": config.DoclingURL,
+	})
+	logger.Info("Creating new Docling provider")
+
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	client.RetryWaitMin = 1 * time.Second
+	client.RetryWaitMax = 10 * time.Second
+	client.Logger = logger // Use the logger from the ocr package
+
+	provider := &DoclingProvider{
+		baseURL:    config.DoclingURL,
+		imageExportMode: config.DoclingImageExportMode,
+		httpClient: client,
+	}
+
+	logger.Info("Successfully initialized Docling provider")
+	return provider, nil
+}
+
+// ProcessImage sends the image content to the Docling server for OCR
+func (p *DoclingProvider) ProcessImage(ctx context.Context, imageContent []byte) (*OCRResult, error) {
+	logger := log.WithFields(logrus.Fields{
+		"provider": "docling",
+		"url":      p.baseURL,
+	})
+	logger.Debug("Starting Docling processing")
+
+	// Prepare multipart request body
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	// Add image file part
+	// Using a generic filename as the actual name isn't critical here
+	part, err := writer.CreateFormFile("files", "image.bin")
+	if err != nil {
+		logger.WithError(err).Error("Failed to create form file")
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+	_, err = io.Copy(part, bytes.NewReader(imageContent))
+	if err != nil {
+		logger.WithError(err).Error("Failed to copy image content to form")
+		return nil, fmt.Errorf("failed to copy image content to form: %w", err)
+	}
+
+	// Add required form fields
+	// Note: Docling expects boolean fields as strings "true"/"false"
+	_ = writer.WriteField("to_formats", "md") // Request plain text output
+	_ = writer.WriteField("do_ocr", "true")      // Ensure OCR is performed
+	_ = writer.WriteField("pipeline", "vlm")      // Ensure OCR is performed
+	_ = writer.WriteField("image_export_mode", p.imageExportMode)
+
+	// Close multipart writer
+	err = writer.Close()
+	if err != nil {
+		logger.WithError(err).Error("Failed to close multipart writer")
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// Create HTTP request
+	requestURL := p.baseURL + "/v1alpha/convert/file"
+	req, err := retryablehttp.NewRequestWithContext(ctx, "POST", requestURL, &requestBody)
+	if err != nil {
+		logger.WithError(err).Error("Failed to create HTTP request")
+		return nil, fmt.Errorf("error creating Docling request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json") // Ensure we get JSON back
+
+	logger.Debug("Sending request to Docling server")
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		logger.WithError(err).Error("Failed to send request to Docling server")
+		return nil, fmt.Errorf("error sending request to Docling: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.WithError(err).Error("Failed to read Docling response body")
+		return nil, fmt.Errorf("error reading Docling response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logger.WithFields(logrus.Fields{
+			"status_code": resp.StatusCode,
+			"response":    string(respBodyBytes),
+		}).Error("Received non-OK status from Docling")
+		return nil, fmt.Errorf("docling API returned status %d: %s", resp.StatusCode, string(respBodyBytes))
+	}
+
+	// Parse JSON response
+	var doclingResp DoclingConvertResponse
+	if err := json.Unmarshal(respBodyBytes, &doclingResp); err != nil {
+		logger.WithError(err).WithField("response", string(respBodyBytes)).Error("Failed to parse Docling JSON response")
+		return nil, fmt.Errorf("error parsing Docling JSON response: %w", err)
+	}
+
+	// Check Docling status and errors
+	if doclingResp.Status != "success" {
+		logger.WithFields(logrus.Fields{
+			"status": doclingResp.Status,
+			"errors": doclingResp.Errors,
+		}).Error("Docling processing failed")
+		// Handle potential error structures if known, otherwise just report status
+		return nil, fmt.Errorf("docling processing failed with status '%s', errors: %v", doclingResp.Status, doclingResp.Errors)
+	}
+
+	// Extract text content
+	ocrText := doclingResp.Document.TextContent
+	if ocrText == "" {
+		// Fallback to Markdown content if text content is empty (less ideal but better than nothing)
+		ocrText = doclingResp.Document.MdContent
+		logger.Debug("Text content empty, falling back to Markdown content")
+	}
+
+	if ocrText == "" {
+		logger.Warn("Received empty text and markdown content from Docling")
+		// Return empty result instead of error, as the process technically succeeded
+	}
+
+	result := &OCRResult{
+		Text: ocrText,
+		Metadata: map[string]string{
+			"provider": "docling",
+		},
+	}
+
+	logger.WithField("content_length", len(result.Text)).Info("Successfully processed image with Docling")
+	return result, nil
+}
+
+// DoclingConvertResponse mirrors the structure of the /v1alpha/convert/file JSON response
+type DoclingConvertResponse struct {
+	Document DoclingDocumentResponse `json:"document"`
+	Status   string                  `json:"status"`
+	Errors   []interface{}           `json:"errors"` // Define more specifically if needed
+}
+
+// DoclingDocumentResponse mirrors the 'document' part of the response
+type DoclingDocumentResponse struct {
+	Filename   string `json:"filename"`
+	MdContent  string `json:"md_content"`
+	TextContent string `json:"text_content"`
+	// Add other fields like json_content, html_content if needed
+}

--- a/ocr/docling_provider.go
+++ b/ocr/docling_provider.go
@@ -45,7 +45,7 @@ func newDoclingProvider(config Config) (*DoclingProvider, error) {
 }
 
 // ProcessImage sends the image content to the Docling server for OCR
-func (p *DoclingProvider) ProcessImage(ctx context.Context, imageContent []byte) (*OCRResult, error) {
+func (p *DoclingProvider) ProcessImage(ctx context.Context, imageContent []byte, pageNumber int) (*OCRResult, error) {
 	logger := log.WithFields(logrus.Fields{
 		"provider": "docling",
 		"url":      p.baseURL,
@@ -93,6 +93,7 @@ func (p *DoclingProvider) ProcessImage(ctx context.Context, imageContent []byte)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Accept", "application/json") // Ensure we get JSON back
 
+	p.httpClient.HTTPClient.Timeout = 60 * time.Second
 	logger.Debug("Sending request to Docling server")
 	resp, err := p.httpClient.Do(req)
 	if err != nil {

--- a/ocr/docling_provider_test.go
+++ b/ocr/docling_provider_test.go
@@ -175,7 +175,7 @@ func TestDoclingProvider_ProcessImage(t *testing.T) {
 				defer server.Close()
 			}
 
-			result, err := provider.ProcessImage(context.Background(), sampleImageContent)
+			result, err := provider.ProcessImage(context.Background(), sampleImageContent, 1)
 
 			if tt.expectedErrStr != "" {
 				assert.Error(t, err)

--- a/ocr/docling_provider_test.go
+++ b/ocr/docling_provider_test.go
@@ -27,6 +27,7 @@ func newTestDoclingProvider(serverURL string) *DoclingProvider {
 
 	return &DoclingProvider{
 		baseURL:    serverURL,
+		imageExportMode: "md",
 		httpClient: client,
 	}
 }

--- a/ocr/docling_provider_test.go
+++ b/ocr/docling_provider_test.go
@@ -1,0 +1,190 @@
+package ocr
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper function to create a mock Docling server
+func setupDoclingTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	return server
+}
+
+// Helper function to create a DoclingProvider for testing
+func newTestDoclingProvider(serverURL string) *DoclingProvider {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 0 // Disable retries for testing
+	client.Logger = nil  // Suppress log output during tests
+
+	return &DoclingProvider{
+		baseURL:    serverURL,
+		httpClient: client,
+	}
+}
+
+func TestDoclingProvider_ProcessImage(t *testing.T) {
+	sampleImageContent := []byte("dummy image data")
+
+	tests := []struct {
+		name           string
+		mockHandler    func(w http.ResponseWriter, r *http.Request)
+		expectedResult *OCRResult
+		expectedErrStr string // Substring of the expected error message
+		checkRequest   func(r *http.Request) // Optional function to validate the request received by the server
+	}{
+		{
+			name: "Success Case",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/v1alpha/convert/file", r.URL.Path)
+				assert.Equal(t, "POST", r.Method)
+				assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+				resp := DoclingConvertResponse{
+					Status: "success",
+					Document: DoclingDocumentResponse{
+						TextContent: "Successfully processed text.",
+						Filename:    "image.bin",
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedResult: &OCRResult{
+				Text: "Successfully processed text.",
+				Metadata: map[string]string{
+					"provider": "docling",
+				},
+			},
+			checkRequest: func(r *http.Request) {
+				err := r.ParseMultipartForm(10 << 20) // 10 MB max memory
+				assert.NoError(t, err)
+				assert.Equal(t, "text", r.FormValue("to_formats"))
+				assert.Equal(t, "true", r.FormValue("do_ocr"))
+				f, fh, err := r.FormFile("files")
+				assert.NoError(t, err)
+				assert.NotNil(t, f)
+				assert.Equal(t, "image.bin", fh.Filename)
+				fileContent, _ := io.ReadAll(f)
+				assert.Equal(t, sampleImageContent, fileContent)
+				f.Close()
+			},
+		},
+		{
+			name: "Success Case - Fallback to Markdown",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := DoclingConvertResponse{
+					Status: "success",
+					Document: DoclingDocumentResponse{
+						TextContent: "", // Empty text content
+						MdContent:   "# Markdown Content",
+						Filename:    "image.bin",
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedResult: &OCRResult{
+				Text: "# Markdown Content",
+				Metadata: map[string]string{
+					"provider": "docling",
+				},
+			},
+		},
+		{
+			name: "Success Case - Empty Content",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := DoclingConvertResponse{
+					Status: "success",
+					Document: DoclingDocumentResponse{
+						TextContent: "",
+						MdContent:   "",
+						Filename:    "image.bin",
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedResult: &OCRResult{
+				Text: "",
+				Metadata: map[string]string{
+					"provider": "docling",
+				},
+			},
+		},
+		{
+			name: "Docling Processing Error",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := DoclingConvertResponse{
+					Status: "failure",
+					Errors: []interface{}{"Some internal docling error"},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedErrStr: "docling processing failed with status 'failure'",
+		},
+		{
+			name: "Invalid JSON Response",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("this is not json"))
+			},
+			expectedErrStr: "error parsing Docling JSON response",
+		},
+		{
+			name: "Server Connection Error",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				// Handler won't be reached if server is closed
+			},
+			expectedErrStr: "connection refused", // Expect a connection error substring
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Wrap the handler to allow request checking
+			checkedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.checkRequest != nil {
+					tt.checkRequest(r)
+				}
+				tt.mockHandler(w, r)
+			})
+
+			server := setupDoclingTestServer(t, checkedHandler)
+			
+			serverURL := server.URL
+			if tt.name == "Server Connection Error" {
+				server.Close() // Intentionally close server to cause connection error
+			}
+
+			provider := newTestDoclingProvider(serverURL)
+
+			// Only close the server if it wasn't closed for the connection error test
+			if tt.name != "Server Connection Error" {
+				defer server.Close()
+			}
+
+			result, err := provider.ProcessImage(context.Background(), sampleImageContent)
+
+			if tt.expectedErrStr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrStr)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+} 

--- a/ocr/provider.go
+++ b/ocr/provider.go
@@ -49,6 +49,10 @@ type Config struct {
 	AzureTimeout             int    // Optional, defaults to 120 seconds
 	AzureOutputContentFormat string // Optional, defaults to ""
 
+	// Docling settings
+	DoclingURL string
+	DoclingImageExportMode string
+
 	// OCR output options
 	EnableHOCR     bool   // Whether to request hOCR output if supported by the provider
 	HOCROutputPath string // Where to save hOCR output files
@@ -84,6 +88,13 @@ func NewProvider(config Config) (Provider, error) {
 			return nil, fmt.Errorf("missing required Azure Document Intelligence configuration")
 		}
 		return newAzureProvider(config)
+
+	case "docling":
+		if config.DoclingURL == "" {
+			return nil, fmt.Errorf("missing required Docling configuration (DOCLING_URL)")
+		}
+		log.WithField("url", config.DoclingURL).Info("Using Docling provider")
+		return newDoclingProvider(config)
 
 	default:
 		return nil, fmt.Errorf("unsupported OCR provider: %s", config.Provider)


### PR DESCRIPTION
Docling is pretty cool and we talked on reddit about integrating it. Latest version of docling-serve comes with vlm pipeline so this was easy!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new OCR provider, "Docling Server," enabling integration with self-hosted Docling OCR services.
  - Introduced configuration options for Docling Server, including new environment variables for server URL, image export mode, and hOCR generation.

- **Documentation**
  - Updated documentation to include setup instructions and configuration details for the new Docling Server OCR provider.

- **Tests**
  - Added comprehensive tests to ensure correct integration and error handling for the Docling Server OCR provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->