### PR TITLE
feat(ocr): support OCR processing PDFs directly

### DIFF
--- a/background.go
+++ b/background.go
@@ -202,6 +202,7 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			ReplaceOriginal: app.pdfReplace,
 			CopyMetadata:    app.pdfCopyMetadata,
 			LimitPages:      limitOcrPages,
+			ProcessMode:     app.ocrProcessMode,
 		}
 
 		// Use the DocumentProcessor interface instead of calling the method directly

--- a/background_test.go
+++ b/background_test.go
@@ -519,12 +519,14 @@ func TestProcessAutoOcrTagDocuments(t *testing.T) {
 
 			// Create test app with mocks
 			app := &App{
-				Client:            client,
-				Database:          env.db,
-				ocrProvider:       &mockOCRProvider{text: tc.mockOCRText},
-				docProcessor:      docProcessor,
-				pdfOCRTagging:     tc.pdfOCRTagging,
-				pdfOCRCompleteTag: pdfOCRCompleteTag,
+				Client:             client,
+				Database:           env.db,
+				ocrProvider:        &mockOCRProvider{text: tc.mockOCRText},
+				docProcessor:       docProcessor,
+				ocrProcessMode:     "image",
+				pdfOCRTagging:      tc.pdfOCRTagging,
+				pdfOCRCompleteTag:  pdfOCRCompleteTag,
+				pdfSkipExistingOCR: false,
 			}
 
 			// Test the processAutoOcrTagDocuments method

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,9 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hhrutter/lzw v1.0.0 // indirect
+	github.com/hhrutter/pkcs7 v0.2.0 // indirect
+	github.com/hhrutter/tiff v1.0.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -63,16 +66,19 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pdfcpu/pdfcpu v0.10.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/phpdave11/gofpdi v1.0.13 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -90,7 +96,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/arch v0.15.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/image v0.15.0 // indirect
+	golang.org/x/image v0.26.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
@@ -100,5 +106,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250505200425-f936aa4a68b2 // indirect
 	google.golang.org/grpc v1.72.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,12 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hhrutter/lzw v1.0.0 h1:laL89Llp86W3rRs83LvKbwYRx6INE8gDn0XNb1oXtm0=
+github.com/hhrutter/lzw v1.0.0/go.mod h1:2HC6DJSn/n6iAZfgM3Pg+cP1KxeWc3ezG8bBqW5+WEo=
+github.com/hhrutter/pkcs7 v0.2.0 h1:i4HN2XMbGQpZRnKBLsUwO3dSckzgX142TNqY/KfXg+I=
+github.com/hhrutter/pkcs7 v0.2.0/go.mod h1:aEzKz0+ZAlz7YaEMY47jDHL14hVWD6iXt0AgqgAvWgE=
+github.com/hhrutter/tiff v1.0.2 h1:7H3FQQpKu/i5WaSChoD1nnJbGx4MxU5TlNqqpxw55z8=
+github.com/hhrutter/tiff v1.0.2/go.mod h1:pcOeuK5loFUE7Y/WnzGw20YxUdnqjY1P0Jlcieb/cCw=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -127,6 +133,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -138,6 +146,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pdfcpu/pdfcpu v0.10.2 h1:DB2dWuoq0eF0QwHjgyLirYKLTCzFOoZdmmIUSu72aL0=
+github.com/pdfcpu/pdfcpu v0.10.2/go.mod h1:Q2Z3sqdRqHTdIq1mPAUl8nfAoim8p3c1ASOaQ10mCpE=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/phpdave11/gofpdi v1.0.13 h1:o61duiW8M9sMlkVXWlvP92sZJtGKENvW3VExs6dZukQ=
@@ -149,6 +159,9 @@ github.com/pkoukk/tiktoken-go v0.1.7 h1:qOBHXX4PHtvIvmOtyg1EeKlwFRiMKAcoMp4Q+bLQ
 github.com/pkoukk/tiktoken-go v0.1.7/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -214,6 +227,8 @@ golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqj
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
 golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
+golang.org/x/image v0.26.0 h1:4XjIFEZWQmCZi6Wv8BoxsDhRU3RVnLX04dToTDAEPlY=
+golang.org/x/image v0.26.0/go.mod h1:lcxbMFAovzpnJxzXS3nyL83K27tmqtKzIJpctK8YO5c=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=

--- a/ocr.go
+++ b/ocr.go
@@ -51,6 +51,8 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	processMode := options.ProcessMode
 	if processMode == "" {
 		processMode = app.ocrProcessMode
+	} else if processMode != "image" && processMode != "pdf" && processMode != "whole_pdf" {
+		return nil, fmt.Errorf("invalid ProcessMode: %s, must be one of: image, pdf, whole_pdf", processMode)
 	}
 
 	// Skip OCR if PDF already has OCR

--- a/ocr.go
+++ b/ocr.go
@@ -311,11 +311,12 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 					}
 
 					// SAFETY CHECK: Don't generate PDF if we're processing fewer pages than original document
-					if processedPageCount < totalPdfPages && pageLimit > 0 {
+					if processedPageCount != totalPdfPages {
 						docLogger.WithFields(logrus.Fields{
 							"processed_pages": processedPageCount,
 							"total_pages":     totalPdfPages,
 							"limit":           pageLimit,
+							"process_mode":    processMode,
 						}).Warn("Not generating PDF because fewer pages were processed than exist in the original document")
 					} else {
 						docLogger.Info("Applying OCR to PDF")

--- a/ocr_test.go
+++ b/ocr_test.go
@@ -265,10 +265,12 @@ func TestUploadProcessedPDF(t *testing.T) {
 			deleteDocCalled = false
 
 			app := &App{
-				Client:            env.client,
-				Database:          env.db,
-				pdfOCRTagging:     tc.expectTagging,
-				pdfOCRCompleteTag: "paperless-gpt-ocr-complete",
+				Client:             env.client,
+				Database:           env.db,
+				pdfOCRTagging:      tc.expectTagging,
+				pdfOCRCompleteTag:  "paperless-gpt-ocr-complete",
+				ocrProcessMode:     "image",
+				pdfSkipExistingOCR: false,
 			}
 
 			logger := logrus.WithField("test", "upload_pdf")

--- a/paperless.go
+++ b/paperless.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/disintegration/imaging"
 	"github.com/gen2brain/go-fitz"
+	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
@@ -564,9 +565,9 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 // DownloadDocumentAsImages downloads the PDF file of the specified document and converts it to images
 // If limitPages > 0, only the first N pages will be processed
 // Returns the image paths and the total number of pages in the original document
-func (client *PaperlessClient) DownloadDocumentAsImages(ctx context.Context, documentId int, limitPages int) ([]string, int, error) {
+func (client *PaperlessClient) DownloadDocumentAsImages(ctx context.Context, documentID int, limitPages int) ([]string, int, error) {
 	// Create a directory named after the document ID
-	docDir := filepath.Join(client.GetCacheFolder(), fmt.Sprintf("document-%d", documentId))
+	docDir := filepath.Join(client.GetCacheFolder(), fmt.Sprintf("document-%d", documentID))
 	if _, err := os.Stat(docDir); os.IsNotExist(err) {
 		err = os.MkdirAll(docDir, 0755)
 		if err != nil {
@@ -575,7 +576,7 @@ func (client *PaperlessClient) DownloadDocumentAsImages(ctx context.Context, doc
 	}
 
 	// Proceed with downloading the document to get the total page count
-	path := fmt.Sprintf("api/documents/%d/download/", documentId)
+	path := fmt.Sprintf("api/documents/%d/download/", documentID)
 	resp, err := client.Do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, 0, err
@@ -584,7 +585,7 @@ func (client *PaperlessClient) DownloadDocumentAsImages(ctx context.Context, doc
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, 0, fmt.Errorf("error downloading document %d: %d, %s", documentId, resp.StatusCode, string(bodyBytes))
+		return nil, 0, fmt.Errorf("error downloading document %d: %d, %s", documentID, resp.StatusCode, string(bodyBytes))
 	}
 
 	pdfData, err := io.ReadAll(resp.Body)
@@ -750,6 +751,120 @@ func (client *PaperlessClient) DownloadDocumentAsImages(ctx context.Context, doc
 	slices.Sort(imagePaths)
 
 	return imagePaths, totalPages, nil
+}
+
+// DownloadDocumentAsPDF downloads the PDF file of the specified document and splits it into individual PDFs if needed
+// If limitPages > 0, only the first N pages will be processed
+// Returns the PDF paths, original PDF data, and the total number of pages in the original document
+func (client *PaperlessClient) DownloadDocumentAsPDF(ctx context.Context, documentID int, limitPages int, split bool) ([]string, []byte, int, error) {
+	// Create a directory named after the document ID
+	docDir := filepath.Join(client.GetCacheFolder(), fmt.Sprintf("document-%d-pdf", documentID))
+	if _, err := os.Stat(docDir); os.IsNotExist(err) {
+		err = os.MkdirAll(docDir, 0755)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+	}
+
+	// Proceed with downloading the document
+	path := fmt.Sprintf("api/documents/%d/download/?original=true", documentID)
+	resp, err := client.Do(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, nil, 0, fmt.Errorf("error downloading document %d: %d, %s", documentID, resp.StatusCode, string(bodyBytes))
+	}
+
+	pdfData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	// Save the original PDF
+	originalPDFPath := filepath.Join(docDir, "original.pdf")
+	err = os.WriteFile(originalPDFPath, pdfData, 0644)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	// Get the number of pages in the PDF
+	tmpFile, err := os.CreateTemp("", "document-*.pdf")
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write(pdfData)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	tmpFile.Close()
+
+	doc, err := fitz.New(tmpFile.Name())
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer doc.Close()
+
+	totalPages := doc.NumPage()
+	pagesToProcess := totalPages
+
+	if limitPages > 0 && limitPages < totalPages {
+		pagesToProcess = limitPages
+	}
+
+	// If skipping splitting is requested, return early with empty paths array
+	if !split {
+		return []string{}, pdfData, totalPages, nil
+	}
+
+	// Continue with splitting logic only if we're not skipping it
+	// Check if PDFs already exist
+	var pdfPaths []string
+	for n := 0; n < pagesToProcess; n++ {
+		pdfPath := filepath.Join(docDir, fmt.Sprintf("page%03d.pdf", n))
+		if _, err := os.Stat(pdfPath); err == nil {
+			// File exists
+			pdfPaths = append(pdfPaths, pdfPath)
+		}
+	}
+
+	// If all PDFs exist, return them
+	if len(pdfPaths) == pagesToProcess {
+		return pdfPaths, pdfData, totalPages, nil
+	}
+
+	// Clear existing PDFs to ensure consistency
+	pdfPaths = []string{}
+
+	// Use pdfcpu to split the PDF
+	err = api.SplitFile(originalPDFPath, docDir, 1, nil)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("error splitting PDF: %w", err)
+	}
+
+	// pdfcpu creates files with names like "original_1.pdf", "original_2.pdf", etc.
+	pdfPaths = []string{}
+	for n := 0; n < pagesToProcess; n++ {
+		// The expected output from pdfcpu SplitFile
+		filePath := filepath.Join(docDir, fmt.Sprintf("original_%d.pdf", n+1))
+
+		// Check if the file exists
+		if _, err := os.Stat(filePath); err == nil {
+			pdfPaths = append(pdfPaths, filePath)
+		} else {
+			return nil, nil, 0, fmt.Errorf("expected split PDF not found: %s", filePath)
+		}
+	}
+
+	// Sort the PDF paths to ensure they are in order
+	slices.Sort(pdfPaths)
+
+	return pdfPaths, pdfData, totalPages, nil
 }
 
 // GetCacheFolder returns the cache folder for the PaperlessClient

--- a/paperless_test.go
+++ b/paperless_test.go
@@ -439,3 +439,34 @@ func TestDownloadDocumentAsImages_ManyPages(t *testing.T) {
 	// Verify total pages count
 	assert.Equal(t, 52, totalPages, "Total pages should be 52")
 }
+
+// TestDownloadDocumentAsPDF tests the DownloadDocumentAsPDF method
+func TestDownloadDocumentAsPDF(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.teardown()
+
+	documentID := 123
+
+	// Get sample PDF from tests/pdf/sample.pdf
+	pdfFile := "tests/pdf/sample.pdf"
+	pdfContent, err := os.ReadFile(pdfFile)
+	require.NoError(t, err)
+
+	// Set mock response
+	downloadPath := fmt.Sprintf("/api/documents/%d/download/", documentID)
+	env.setMockResponse(downloadPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(pdfContent)
+	})
+
+	ctx := context.Background()
+
+	// Test without PDF splitting
+	pdfPaths, pdfData, totalPages, err := env.client.DownloadDocumentAsPDF(ctx, documentID, 0, false)
+	require.NoError(t, err)
+	assert.Empty(t, pdfPaths, "No paths should be returned when split=false")
+	assert.Equal(t, pdfContent, pdfData)
+	assert.Equal(t, 1, totalPages)
+
+	// Testing with splitting=true would be more complex so we'll skip that for simplicity
+}

--- a/types.go
+++ b/types.go
@@ -120,10 +120,11 @@ type Correspondent struct {
 
 // OCROptions contains options for the OCR processing
 type OCROptions struct {
-	UploadPDF       bool // Whether to upload the generated PDF
-	ReplaceOriginal bool // Whether to delete the original document after uploading
-	CopyMetadata    bool // Whether to copy metadata from the original document
-	LimitPages      int  // Limit on the number of pages to process (0 = no limit)
+	UploadPDF       bool   // Whether to upload the generated PDF
+	ReplaceOriginal bool   // Whether to delete the original document after uploading
+	CopyMetadata    bool   // Whether to copy metadata from the original document
+	LimitPages      int    // Limit on the number of pages to process (0 = no limit)
+	ProcessMode     string // OCR processing mode: "image" (default) or "pdf"
 }
 
 // ClientInterface defines the interface for PaperlessClient operations
@@ -135,6 +136,7 @@ type ClientInterface interface {
 	GetAllCorrespondents(ctx context.Context) (map[string]int, error)
 	CreateTag(ctx context.Context, tagName string) (int, error)
 	DownloadDocumentAsImages(ctx context.Context, documentID int, pageLimit int) ([]string, int, error)
+	DownloadDocumentAsPDF(ctx context.Context, documentID int, limitPages int, split bool) ([]string, []byte, int, error)
 	UploadDocument(ctx context.Context, data []byte, filename string, metadata map[string]interface{}) (string, error)
 	GetTaskStatus(ctx context.Context, taskID string) (map[string]interface{}, error)
 	DeleteDocument(ctx context.Context, documentID int) error


### PR DESCRIPTION
Implements three OCR processing modes:
- `image` (default): converts PDF pages to images first
- `pdf`: processes PDF pages directly
- `whole_pdf`: processes entire PDF at once

Also adds ability to detect and skip PDFs with existing OCR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple OCR processing modes: "image" (default), "pdf" (per-page), and "whole_pdf" (entire document at once).
  - Introduced an option to detect and skip OCR on PDFs that already contain OCR text, configurable via environment variable.
  - Added functionality to download original PDFs and optionally split them into single-page PDFs for processing.

- **Documentation**
  - Updated user guide with detailed explanations of new OCR processing modes, configuration options, and usage examples.
  - Expanded environment variable documentation and Docker Compose examples to reflect new features.

- **Bug Fixes**
  - Improved error handling and logging for various OCR processing scenarios.

- **Tests**
  - Added and updated tests to cover new OCR processing modes and PDF download functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->