### PR TITLE
fix: the split pdf logic to be consistent with the output from pdfcpu

### DIFF
--- a/paperless.go
+++ b/paperless.go
@@ -826,7 +826,7 @@ func (client *PaperlessClient) DownloadDocumentAsPDF(ctx context.Context, docume
 	// Check if PDFs already exist
 	var pdfPaths []string
 	for n := 0; n < pagesToProcess; n++ {
-		pdfPath := filepath.Join(docDir, fmt.Sprintf("page%d.pdf", n))
+		pdfPath := filepath.Join(docDir, fmt.Sprintf("original_%d.pdf", n))
 		if _, err := os.Stat(pdfPath); err == nil {
 			// File exists
 			pdfPaths = append(pdfPaths, pdfPath)
@@ -849,7 +849,6 @@ func (client *PaperlessClient) DownloadDocumentAsPDF(ctx context.Context, docume
 	pdfPaths = []string{}
 	for n := 0; n < pagesToProcess; n++ {
 		// The expected output from pdfcpu SplitFile
-		// Zero-pad to 3 digits => original_001.pdf … original_999.pdf
 		filePath := filepath.Join(docDir, fmt.Sprintf("original_%d.pdf", n+1))
 
 		// Check if the file exists


### PR DESCRIPTION
Fixes my issue #433 

!However, there is still an issue with using Azure Document AI: the JSON response for width and height from Azure contains floats instead of integers.
`		"pages": [
			{
				"pageNumber": 1,
				"angle": 0.20013409852981567,
				"width": 8.2639,
				"height": 11.6944,
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the naming pattern for split PDF files by removing zero-padding from filenames. Split files are now named with non-padded numeric suffixes (e.g., original_1.pdf, original_2.pdf).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->