### PR TITLE
feat: add structured output support for Ollama LLM

### DIFF
--- a/app_llm.go
+++ b/app_llm.go
@@ -12,7 +12,6 @@ import (
 	_ "image/jpeg"
 
 	"github.com/sirupsen/logrus"
-	"github.com/tmc/langchaingo/llms"
 )
 
 // getSuggestedCorrespondent generates a suggested correspondent for a document using the LLM
@@ -54,7 +53,7 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 	prompt := promptBuffer.String()
 	log.Debugf("Correspondent suggestion prompt: %s", prompt)
 
-	completion, err := app.callLLMWithStructuredOutput(ctx, prompt, useStructured, CorrespondentResponse{})
+	completion, err := app.callLLMWithStructuredOutput(ctx, prompt, useStructured, StructuredCorrespondentResponse{})
 	if err != nil {
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
@@ -63,7 +62,7 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 
 	// Parse structured response if enabled
 	if useStructured {
-		var corrResp CorrespondentResponse
+		var corrResp StructuredCorrespondentResponse
 		if err := parseStructuredResponse(response, &corrResp); err == nil {
 			return corrResp.Correspondent, nil
 		}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"

--- a/structured_output.go
+++ b/structured_output.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+// Structured output response schemas
+type TitleResponse struct {
+	Title string `json:"title"`
+}
+
+type TagsResponse struct {
+	Tags []string `json:"tags"`
+}
+
+type CorrespondentResponse struct {
+	Correspondent string `json:"correspondent"`
+}
+
+type CreatedDateResponse struct {
+	CreatedDate string `json:"created_date"`
+}
+
+// isStructuredOutputEnabled checks if structured output should be used
+func isStructuredOutputEnabled() bool {
+	return ollamaStructuredOutput && strings.ToLower(llmProvider) == "ollama"
+}
+
+// callLLMWithStructuredOutput makes an LLM call with optional structured output
+func (app *App) callLLMWithStructuredOutput(ctx context.Context, prompt string, useStructured bool, schema interface{}) (*llms.ContentResponse, error) {
+	messages := []llms.MessageContent{
+		{
+			Parts: []llms.ContentPart{
+				llms.TextContent{
+					Text: prompt,
+				},
+			},
+			Role: llms.ChatMessageTypeHuman,
+		},
+	}
+
+	var options []llms.CallOption
+	if useStructured && schema != nil {
+		// Add structured output options for Ollama
+		options = append(options, llms.WithJSONMode())
+	}
+
+	return app.LLM.GenerateContent(ctx, messages, options...)
+}
+
+// parseStructuredResponse attempts to parse JSON response, falls back to text if needed
+func parseStructuredResponse(response string, target interface{}) error {
+	// Try to parse as JSON first
+	if err := json.Unmarshal([]byte(response), target); err != nil {
+		return fmt.Errorf("failed to parse structured response: %w", err)
+	}
+	return nil
+}

--- a/structured_output.go
+++ b/structured_output.go
@@ -18,7 +18,7 @@ type TagsResponse struct {
 	Tags []string `json:"tags"`
 }
 
-type CorrespondentResponse struct {
+type StructuredCorrespondentResponse struct {
 	Correspondent string `json:"correspondent"`
 }
 


### PR DESCRIPTION
warning: this might be AI slop.

Basically: it does not seem to be that structured output is used, even though it's been supported by ollama and all major providers for a while now. To me this would enable saner and mofe reliable output parsing.

I asked llms arround for a tentative illistration of what that might look like because i'm bad at go.

I didn't find anywhere what command you used to run the test suite so this is a fully blind PR. If you could give me pointers for that it'd help me be more helpful


Edit: forgot to specify : by asking a "think" key as first element of the structured output we still have the benefit of reasonning models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for structured JSON output for document suggestions (title, tags, correspondent, created date) when enabled via an environment variable.
  - Users can now receive metadata suggestions in a consistent JSON format, improving integration with other tools.

- **Bug Fixes**
  - Improved fallback handling ensures plain text suggestions are provided if structured output parsing fails.

- **Chores**
  - Introduced new environment variable to control structured output mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->