### PR TITLE
feat: Add strict OCR instructions to prevent hallucination and handle unreadable text

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,7 +156,9 @@ The data will be provided using an XML-like format for clarity:
 {{.Content}}
 </content>
 `
-	defaultOcrPrompt = `Just transcribe the text in this image and preserve the formatting and layout (high quality OCR). Do that for ALL the text in the image. Be thorough and pay attention. This is very important. The image is from a text document so be sure to continue until the bottom of the page. Thanks a lot! You tend to forget about some text in the image so please focus! Use markdown format but without a code block.`
+	defaultOcrPrompt = `Just transcribe the text in this image and preserve the formatting and layout (high quality OCR). Do that for ALL the text in the image. Be thorough and pay attention. This is very important. The image is from a text document so be sure to continue until the bottom of the page. Thanks a lot! You tend to forget about some text in the image so please focus! Use markdown format but without a code block.
+
+IMPORTANT: Never hallucinate or make up text that isn't clearly visible. If any text or part of the image is unclear, blurry, or unreadable, use "[UNREADABLE]" at that exact location instead of guessing what it might say. Only transcribe text that you can clearly and confidently read.`
 )
 
 // App struct to hold dependencies


### PR DESCRIPTION
The current prompts does not specifically ask to avoid hallucination and don't give clear instructions on how to deal with unreadable portion of images AFAIK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated OCR prompt to strictly transcribe only clearly readable text and insert "[UNREADABLE]" for unclear sections, ensuring greater accuracy in OCR results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->