### PR TITLE
fix(tags): If PDF_OCR_COMPLETE_TAG == AUTO_TAG, the OCR complete tag isn't added

### DIFF
--- a/background.go
+++ b/background.go
@@ -122,9 +122,17 @@ func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
 			continue
 		}
 
+		// Ensure autoTag is removed after processing to prevent loops
+		for i := range suggestions {
+			suggestions[i].RemoveTags = append(suggestions[i].RemoveTags, autoTag)
+			// Ensure uniqueness if autoTag was already in RemoveTags for some reason
+			slices.Sort(suggestions[i].RemoveTags)
+			suggestions[i].RemoveTags = slices.Compact(suggestions[i].RemoveTags)
+		}
+
 		err = app.Client.UpdateDocuments(ctx, suggestions, app.Database, false)
 		if err != nil {
-			err = fmt.Errorf("error updating document %d: %w", document.ID, err)
+		err = fmt.Errorf("error updating document %d: %w", document.ID, err)
 			docLogger.Error(err.Error())
 			errs = append(errs, err)
 			continue

--- a/paperless.go
+++ b/paperless.go
@@ -420,8 +420,6 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		} else {
 			// We have suggested tags to change
 			originalFields["tags"] = originalTags
-			// remove autoTag to prevent infinite loop - this is required in case of undo
-			tags = removeTagFromList(tags, autoTag)
 
 			if document.KeepOriginalTags {
 				// Keep original tags


### PR DESCRIPTION
Addresses: https://github.com/icereed/paperless-gpt/issues/438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tag handling to ensure automatic tags are correctly removed from documents after processing, preventing potential re-processing loops.
  - Enhanced tag management to avoid duplicate tags when updating documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->