### PR TITLE
Use relative URLs, so forwarding a sub-path from a reverse proxy works.

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build --base=./",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "echo \"TODO\"",

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -6,8 +6,12 @@ import ExperimentalOCR from './ExperimentalOCR'; // New component
 import History from './History';
 
 const App: React.FC = () => {
+  // Keep the base path (path prefix from reverse-proxy) and remove the app path,
+  // convert "/" to "" so Router basename is empty at root.
+  const rawBasename = window.location.pathname.replace(/(\/[^/]+)$/, "/");
+  const basename = rawBasename === "/" ? "" : rawBasename;
   return (
-    <Router basename={window.location.pathname.replace(/(\/[^/]+)$/, "")}>
+    <Router basename={basename}>
       <div className="flex h-screen flex-col">
         <div className="flex flex-1 overflow-hidden">
           <Sidebar onSelectPage={(page) => console.log(page)} />

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -7,7 +7,7 @@ import History from './History';
 
 const App: React.FC = () => {
   return (
-    <Router>
+    <Router basename={window.location.pathname.replace(/(\/[^/]+)$/, "")}>
       <div className="flex h-screen flex-col">
         <div className="flex flex-1 overflow-hidden">
           <Sidebar onSelectPage={(page) => console.log(page)} />

--- a/web-app/src/DocumentProcessor.tsx
+++ b/web-app/src/DocumentProcessor.tsx
@@ -56,9 +56,9 @@ const DocumentProcessor: React.FC = () => {
   const fetchInitialData = useCallback(async () => {
     try {
       const [filterTagRes, documentsRes, tagsRes] = await Promise.all([
-        axios.get<{ tag: string }>("/api/filter-tag"),
-        axios.get<Document[]>("/api/documents"),
-        axios.get<Record<string, number>>("/api/tags"),
+        axios.get<{ tag: string }>("./api/filter-tag"),
+        axios.get<Document[]>("./api/documents"),
+        axios.get<Record<string, number>>("./api/tags"),
       ]);
 
       setFilterTag(filterTagRes.data.tag);
@@ -93,7 +93,7 @@ const DocumentProcessor: React.FC = () => {
       };
 
       const { data } = await axios.post<DocumentSuggestion[]>(
-        "/api/generate-suggestions",
+        "./api/generate-suggestions",
         requestPayload
       );
       setSuggestions(data);
@@ -109,7 +109,7 @@ const DocumentProcessor: React.FC = () => {
     setUpdating(true);
     setError(null);
     try {
-      await axios.patch("/api/update-documents", suggestions);
+      await axios.patch("./api/update-documents", suggestions);
       setIsSuccessModalOpen(true);
       setSuggestions([]);
     } catch (err) {
@@ -179,7 +179,7 @@ const DocumentProcessor: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const { data } = await axios.get<Document[]>("/api/documents");
+      const { data } = await axios.get<Document[]>("./api/documents");
       setDocuments(data);
     } catch (err) {
       console.error("Error reloading documents:", err);
@@ -194,7 +194,7 @@ const DocumentProcessor: React.FC = () => {
       const interval = setInterval(async () => {
         setError(null);
         try {
-          const { data } = await axios.get<Document[]>("/api/documents");
+          const { data } = await axios.get<Document[]>("./api/documents");
           setDocuments(data);
         } catch (err) {
           console.error("Error reloading documents:", err);

--- a/web-app/src/ExperimentalOCR.tsx
+++ b/web-app/src/ExperimentalOCR.tsx
@@ -18,7 +18,7 @@ const ExperimentalOCR: React.FC = () => {
     if (!documentId) return;
 
     try {
-      const response = await axios.get<Document>(`/api/documents/${documentId}`);
+      const response = await axios.get<Document>(`./api/documents/${documentId}`);
       setDocumentDetails(response.data);
     } catch (err) {
       console.error("Error fetching document details:", err);
@@ -38,7 +38,7 @@ const ExperimentalOCR: React.FC = () => {
       await fetchDocumentDetails(); // Fetch document details before submitting the job
 
       setStatus('Submitting OCR job...');
-      const response = await axios.post(`/api/documents/${documentId}/ocr`);
+      const response = await axios.post(`./api/documents/${documentId}/ocr`);
       setJobId(response.data.job_id);
       setStatus('Job submitted. Processing...');
     } catch (err) {
@@ -51,7 +51,7 @@ const ExperimentalOCR: React.FC = () => {
     if (!jobId) return;
 
     try {
-      const response = await axios.get(`/api/jobs/ocr/${jobId}`);
+      const response = await axios.get(`./api/jobs/ocr/${jobId}`);
       const jobStatus = response.data.status;
       setPagesDone(response.data.pages_done); // Update pages done
       if (jobStatus === 'completed') {
@@ -85,7 +85,7 @@ const ExperimentalOCR: React.FC = () => {
         suggested_content: ocrResult,
       };
 
-      await axios.patch("/api/update-documents", [requestPayload]);
+      await axios.patch("./api/update-documents", [requestPayload]);
       setStatus('Content saved successfully.');
     } catch (err) {
       console.error("Error saving content:", err);

--- a/web-app/src/History.tsx
+++ b/web-app/src/History.tsx
@@ -34,7 +34,7 @@ const History: React.FC = () => {
   useEffect(() => {
     const fetchUrl = async () => {
       try {
-        const response = await fetch('/api/paperless-url');
+        const response = await fetch('./api/paperless-url');
         if (!response.ok) {
           throw new Error('Failed to fetch public URL');
         }
@@ -56,7 +56,7 @@ const History: React.FC = () => {
   const fetchModifications = async (page: number) => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/modifications?page=${page}&pageSize=${pageSize}`);
+      const response = await fetch(`./api/modifications?page=${page}&pageSize=${pageSize}`);
       if (!response.ok) {
         throw new Error('Failed to fetch modifications');
       }
@@ -73,7 +73,7 @@ const History: React.FC = () => {
 
   const handleUndo = async (id: number) => {
     try {
-      const response = await fetch(`/api/undo-modification/${id}`, {
+      const response = await fetch(`./api/undo-modification/${id}`, {
         method: 'POST',
       });
       

--- a/web-app/src/components/Sidebar.tsx
+++ b/web-app/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onSelectPage }) => {
   const fetchOcrEnabled = useCallback(async () => {
     try {
       const res = await axios.get<{ enabled: boolean }>(
-        "/api/experimental/ocr"
+        "./api/experimental/ocr"
       );
       setOcrEnabled(res.data.enabled);
     } catch (err) {
@@ -40,15 +40,15 @@ const Sidebar: React.FC<SidebarProps> = ({ onSelectPage }) => {
   }, [fetchOcrEnabled]);
 
   const menuItems = [
-    { name: "home", path: "/", icon: mdiHomeOutline, title: "Home" },
-    { name: "history", path: "/history", icon: mdiHistory, title: "History" },
+    { name: "home", path: "./", icon: mdiHomeOutline, title: "Home" },
+    { name: "history", path: "./history", icon: mdiHistory, title: "History" },
   ];
 
   // If OCR is enabled, add the OCR menu item
   if (ocrEnabled) {
     menuItems.push({
       name: "ocr",
-      path: "/experimental-ocr",
+      path: "./experimental-ocr",
       icon: mdiTextBoxSearchOutline,
       title: "OCR",
     });
@@ -72,7 +72,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onSelectPage }) => {
         {menuItems.map((item) => (
           <li
             key={item.name}
-            className={location.pathname === item.path ? "active" : ""}
+            className={location.pathname.split('/').at(-1) === item.path.split('/').at(-1) ? "active" : ""}
             onClick={() => handlePageClick(item.name)}
           >
             <Link


### PR DESCRIPTION
Use relative URLs, so forwarding a sub-path from a reverse proxy works.
Note that the reverse proxy/ingress needs to remove the path prefix.
Fixes #132 

references:
- https://vite.dev/guide/build.html#public-base-path
- https://create-react-app.dev/docs/deployment/#building-for-relative-paths
- https://stackoverflow.com/questions/57572259/react-router-with-relative-path-deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated all API request URLs to use relative paths, improving compatibility when the app is served from subdirectories.
  * Adjusted sidebar navigation and active state logic to better support relative routing.

* **Chores**
  * Modified the build process to set the correct base path for static assets, enhancing deployment flexibility.
  * Updated routing configuration to dynamically set the base path based on the current location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->