### PR TITLE
fix: ignore invalid CreatedDate

### DIFF
--- a/paperless.go
+++ b/paperless.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"regexp"
 
 	"github.com/disintegration/imaging"
 	"github.com/gen2brain/go-fitz"
@@ -490,8 +491,13 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		// Suggested CreatedDate
 		suggestedCreatedDate := document.SuggestedCreatedDate
 		if suggestedCreatedDate != "" {
-			originalFields["created_date"] = document.OriginalDocument.CreatedDate
-			updatedFields["created_date"] = suggestedCreatedDate
+			// Validate format YYYY-MM-DD
+			if matched := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`).MatchString(suggestedCreatedDate); matched {
+				originalFields["created_date"] = document.OriginalDocument.CreatedDate
+				updatedFields["created_date"] = suggestedCreatedDate
+			} else {
+				log.Warnf("Invalid created_date format for document %d: %s. Expected YYYY-MM-DD, skipping.", documentID, suggestedCreatedDate)
+			}
 		}
 
 		log.Debugf("Document %d: Original fields: %v", documentID, originalFields)


### PR DESCRIPTION
I have a document, that has no specific date on the.
qwen3:8b therefore does not provide a date in the form YYYY-MM-DD, but some thinking with a final result.

This is the error output without the fix:
```
Document 60: Updated fields: map[correspondent:23 created_date:The provided text does not explicitly state a specific date, but it does mention the year **2025**. Since no month or day is provided, we apply the default rules:\n\n1. **If no day is found**, use the **first day of the month** (i.e., 1st).\n2. **If no month is found**, use **January**.\n3. **If no date is found at all**, use **today's date** (which is not applicable here, as the year is provided).\n\nSince the year **2025** is given, and no month or day is specified, the default is to use **January 1st, 2025**.\n\n**Answer:**  \n**2025-01-01** tags:[] title:XXX] Tags: [ ]"
Making HTTP request" method=PATCH url="http://XXX/api/documents/60/"
Error updating document 60: 400, {\"created_date\":[\"Date has wrong format. Use one of these formats instead: YYYY-MM-DD.\"]}"
error updating document 60: error updating document 60: 400, {\"created_date\":[\"Date has wrong format. Use one of these formats instead: YYYY-MM-DD.\"]}" document_id=60
```
(I xxx'ed some content)


Improving the prompt or changing the model might fix this most times, but it could happen any time.

The annoying point here: paperless-gpt goes into a loop by trying the same document(s) again and again.

Therefore I added a check, if the date format looks correct, by asking Copilot for "check that suggestedCreatedDate has the format NNNN-NN-NN where N is a digit". (so no check for a real valid date - let's see if CodeRabbit has a proposal)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for document date fields to ensure only correctly formatted dates (YYYY-MM-DD) are accepted during updates. Invalid date formats are now skipped and a warning is logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->