### PR TITLE
feat: make docker hub push optional

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
+        if: github.repository == 'icereed/paperless-gpt'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -97,7 +98,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: true
+          push: ${{ github.repository == 'icereed/paperless-gpt' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ env.TAGS }}
@@ -129,7 +130,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'icereed/paperless-gpt' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -160,7 +161,7 @@ jobs:
         with:
           context: .
           platforms: linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.repository == 'icereed/paperless-gpt' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ env.TAGS }}
@@ -199,6 +200,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
+        if: github.repository == 'icereed/paperless-gpt'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "paperless-gpt",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
These changes to the GitHub Actions workflow file `.github/workflows/docker-build-and-push.yml` make the Docker Hub push optional.

**Changes:**

- The Docker Hub login and push steps are now only executed when the repository is `icereed/paperless-gpt`.
- This prevents the workflow from failing on forks while preserving the original functionality for the owner.
- The `docker-build-and-push.sh` file has been kept, as the owner may still be using it.

**Benefits:**

- The GitHub Actions will now run successfully on forks.
- The original functionality for the owner is maintained.
