### PR TITLE
fix(ocr): update Docling provider to support PDF processing modes

### DIFF
--- a/main.go
+++ b/main.go
@@ -511,7 +511,7 @@ func validateOCRProviderModeCompatibility(provider, mode string) error {
 		"azure":        {"image"},                     // Azure Document Intelligence only supports image mode
 		"google_docai": {"image", "pdf", "whole_pdf"}, // Google Document AI supports all modes
 		"mistral_ocr":  {"image", "pdf", "whole_pdf"}, // Mistral OCR supports all modes
-		"docling":      {"image"},                     // Docling only supports image mode
+		"docling":      {"image", "pdf", "whole_pdf"}, // Docling supports image and PDF modes
 	}
 
 	modes, exists := supportedModes[provider]


### PR DESCRIPTION
enabled Docling to use pdf and whole_pdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docling OCR provider now supports PDF and whole PDF files in addition to image processing, expanding document format compatibility.

* **Improvements**
  * Enhanced content handling with improved PDF detection and differentiated logging between document types for clearer processing distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->