### PR TITLE
Fix frontend API/base paths when hosting under sub-path (e.g. /ai/)

### DIFF
--- a/web-app/src/ExperimentalOCR.tsx
+++ b/web-app/src/ExperimentalOCR.tsx
@@ -35,7 +35,7 @@ const ExperimentalOCR: React.FC = () => {
   const stopOCRJob = async () => {
     if (!jobId) return;
     try {
-      await axios.post(`/api/ocr/jobs/${jobId}/stop`);
+      await axios.post(`./api/ocr/jobs/${jobId}/stop`);
       setJobStatus('cancelled');
     } catch (err) {
       setError('Failed to stop OCR job.');
@@ -57,7 +57,7 @@ const ExperimentalOCR: React.FC = () => {
   const fetchPerPageResults = useCallback(async () => {
     if (!documentId) return;
     try {
-      const response = await axios.get<{ pages: OCRPageResult[] }>(`/api/documents/${documentId}/ocr_pages`);
+      const response = await axios.get<{ pages: OCRPageResult[] }>(`./api/documents/${documentId}/ocr_pages`);
       setPerPageResults(response.data.pages);
     } catch (err) {
       console.error("Error fetching per-page OCR results:", err);
@@ -168,7 +168,7 @@ const ExperimentalOCR: React.FC = () => {
 
     try {
       const response = await axios.post(
-        `/api/documents/${documentId}/ocr_pages/${pageIdx}/reocr`,
+        `./api/documents/${documentId}/ocr_pages/${pageIdx}/reocr`,
         {},
         { signal: controller.signal }
       );
@@ -213,7 +213,7 @@ const ExperimentalOCR: React.FC = () => {
     }
 
     try {
-      await axios.delete(`/api/documents/${documentId}/ocr_pages/${pageIdx}/reocr`);
+      await axios.delete(`./api/documents/${documentId}/ocr_pages/${pageIdx}/reocr`);
       console.log(`Cancellation request sent for page ${pageIdx}`);
     } catch (err) {
       console.error(`Failed to send cancellation request for page ${pageIdx}:`, err);

--- a/web-app/src/components/CustomFieldsEditor.tsx
+++ b/web-app/src/components/CustomFieldsEditor.tsx
@@ -25,13 +25,13 @@ const CustomFieldsEditor: React.FC = () => {
   const fetchInitialData = useCallback(async (forcePull = false) => {
     setIsLoading(true);
     try {
-      const settingsRes = await fetch('/api/settings');
+      const settingsRes = await fetch('./api/settings');
       if (!settingsRes.ok) throw new Error('Failed to fetch settings');
       const settingsData = await settingsRes.json();
       setSettings(settingsData.settings);
       setInitialSettings(settingsData.settings);
 
-      const customFieldsUrl = forcePull ? '/api/custom_fields?force_pull=true' : '/api/custom_fields';
+      const customFieldsUrl = forcePull ? './api/custom_fields?force_pull=true' : './api/custom_fields';
       const customFieldsRes = await fetch(customFieldsUrl);
       if (!customFieldsRes.ok) throw new Error('Failed to fetch custom fields');
       const customFieldsData = await customFieldsRes.json();
@@ -61,7 +61,7 @@ const CustomFieldsEditor: React.FC = () => {
     setIsSaving(true);
     setError(null);
     try {
-      const response = await fetch('/api/settings', {
+      const response = await fetch('./api/settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(settings),

--- a/web-app/src/components/PromptsEditor.tsx
+++ b/web-app/src/components/PromptsEditor.tsx
@@ -11,7 +11,7 @@ const PromptsEditor: React.FC = () => {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetch('/api/prompts', { signal: controller.signal })
+    fetch('./api/prompts', { signal: controller.signal })
       .then((res) => {
         if (!res.ok) {
           throw new Error('Network response was not ok');
@@ -55,7 +55,7 @@ const PromptsEditor: React.FC = () => {
     if (!selectedPrompt) return;
 
     setIsSaving(true);
-    fetch('/api/prompts', {
+    fetch('./api/prompts', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This pull requests addresses the issue https://github.com/icereed/paperless-gpt/issues/789

**Problem**

When paperless-gpt is hosted under a sub-path (for example https://mypaperless.tld/ai/ behind the main Paperless instance), some frontend features break because backend requests are built as if the app was mounted at /.

This results in requests such as:

https://mypaperless.tld/api/prompts (wrong)
instead of
https://mypaperless.tld/ai/api/prompts (correct)

Core functionality still works (confirmed with 0.22), but newer UI parts fail. A notable example is the Settings menu, which currently cannot load because it requests /api/prompts from the origin root.

**Solution**

This PR makes frontend backend request paths sub-path aware by ensuring API calls are built relative to the application’s base path instead of the domain root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API integration across multiple components to improve routing consistency. All functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->