### PR TITLE
Fix whole_pdf mode page count mismatch preventing PDF generation

### DIFF
--- a/ocr.go
+++ b/ocr.go
@@ -145,7 +145,8 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	if processMode == "whole_pdf" {
 		// Process the entire PDF in one go, skipping the splitting step
 		var pdfBytes []byte
-		_, pdfBytes, totalPdfPages, err := app.Client.DownloadDocumentAsPDF(ctx, documentID, 0, false)
+		var err error
+		_, pdfBytes, totalPdfPages, err = app.Client.DownloadDocumentAsPDF(ctx, documentID, 0, false)
 		if err != nil {
 			return nil, fmt.Errorf("error downloading document PDF for document %d: %w", documentID, err)
 		}


### PR DESCRIPTION
## Summary

- Fixes a Go variable shadowing bug in `ocr.go` where `totalPdfPages` was always `0` in `whole_pdf` mode, causing the safety check to skip PDF generation
- The short variable declaration `:=` on the `DownloadDocumentAsPDF` call created a new local `totalPdfPages` that shadowed the outer function-scoped variable
- Changed to explicit `var` declarations with plain assignment `=` so the outer `totalPdfPages` is correctly updated

## Root Cause

Line 148 in `ocr.go` (before fix):
```go
_, pdfBytes, totalPdfPages, err := app.Client.DownloadDocumentAsPDF(ctx, documentID, 0, false)
```

The `:=` creates a new `totalPdfPages` in the `if` block scope. When the block exits, the outer `totalPdfPages` (declared on line 135) remains `0`. The safety check on line 368 then compares `processedPageCount (1) != totalPdfPages (0)` and skips PDF generation.

## Fix

Declare `pdfBytes` and `err` separately, then use `=` assignment:
```go
var pdfBytes []byte
var err error
_, pdfBytes, totalPdfPages, err = app.Client.DownloadDocumentAsPDF(ctx, documentID, 0, false)
```

Fixes #874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an error handling issue in PDF download functionality that could affect error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->