### PR TITLE
Skip tag update for replaced document when PDF_REPLACE=true

### DIFF
--- a/background.go
+++ b/background.go
@@ -261,9 +261,9 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			docLogger.Infof("Adding OCR complete tag '%s'", app.pdfOCRCompleteTag)
 		}
 
-		// Skip updating the original document if it was replaced (deleted) during OCR.
+		// Skip updating the original document if it was actually replaced (deleted) during OCR.
 		// The replacement document will be processed as a new document on the next cycle.
-		if options.ReplaceOriginal {
+		if options.ReplaceOriginal && processedDoc != nil && processedDoc.ReplacedOriginal {
 			docLogger.Info("Skipping tag update for replaced document (original was deleted)")
 		} else {
 			err = app.Client.UpdateDocuments(ctx, []DocumentSuggestion{

--- a/ocr.go
+++ b/ocr.go
@@ -18,11 +18,12 @@ import (
 
 // ProcessedDocument represents a document after OCR processing
 type ProcessedDocument struct {
-	ID         int
-	Text       string
-	HOCRStruct *hocr.HOCR
-	HOCR       string
-	PDFData    []byte
+	ID               int
+	Text             string
+	HOCRStruct       *hocr.HOCR
+	HOCR             string
+	PDFData          []byte
+	ReplacedOriginal bool // true when the original document was successfully deleted and replaced
 }
 
 // HOCRCapable defines an interface for OCR providers that can generate hOCR
@@ -411,6 +412,8 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 							if options.UploadPDF && pdfData != nil {
 								if err := app.uploadProcessedPDF(ctx, documentID, pdfData, options, docLogger); err != nil {
 									docLogger.WithError(err).Error("Failed to upload processed PDF")
+								} else if options.ReplaceOriginal {
+									processedDoc.ReplacedOriginal = true
 								}
 							}
 						}


### PR DESCRIPTION
## Summary

Fixes #910

When `PDF_REPLACE=true` is enabled, the OCR processing flow deletes the original document and uploads a new one with embedded OCR text. However, after the replacement, `processAutoOcrTagDocuments` still attempts to update tags on the original (now deleted) document, resulting in a 404 error:

```
Update after OCR failed: error updating document 21: unexpected status code: 404: {"detail":"Not found."}
```

This is a cosmetic error — the replacement document is consumed correctly on the next cycle — but it generates noisy error logs and triggers unnecessary error handling/backoff.

## Changes

Added a guard in `processAutoOcrTagDocuments` to skip the `UpdateDocuments` call when `options.ReplaceOriginal` is true. The replacement document will be processed as a new document on the next background processing cycle, so no tag updates are lost.

## Test plan

- Enable `PDF_REPLACE=true` and `PDF_UPLOAD=true`
- Upload a document that triggers OCR processing
- Verify no 404 errors in logs after OCR replacement
- Verify the replacement document is correctly processed on the next cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting so multiple OCR processing errors are surfaced together as a single, clear aggregated error for easier troubleshooting.
  * Refined OCR handling to avoid updating or overwriting the original document when a processed version replaces it in replacement-enabled workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->