### PR TITLE
Fix OCR reasoning cleanup for unclosed/dangling <think> tags (follow-up to #708)

### DIFF
--- a/app_llm.go
+++ b/app_llm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"paperless-gpt/internal/textsanitize"
 	"slices"
 	"strings"
 	"sync"
@@ -67,7 +68,7 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
 
-	response := stripReasoning(strings.TrimSpace(completion.Choices[0].Content))
+	response := textsanitize.StripReasoning(strings.TrimSpace(completion.Choices[0].Content))
 	return response, nil
 }
 
@@ -137,7 +138,7 @@ func (app *App) getSuggestedTags(
 		return nil, fmt.Errorf("error getting response from LLM: %v", err)
 	}
 
-	response := stripReasoning(completion.Choices[0].Content)
+	response := textsanitize.StripReasoning(completion.Choices[0].Content)
 
 	suggestedTags := strings.Split(response, ",")
 	for i, tag := range suggestedTags {
@@ -223,7 +224,7 @@ func (app *App) getSuggestedDocumentType(
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
 
-	response := strings.TrimSpace(stripReasoning(completion.Choices[0].Content))
+	response := strings.TrimSpace(textsanitize.StripReasoning(completion.Choices[0].Content))
 
 	// Validate that the response is in the available document types list
 	for _, docType := range availableDocumentTypes {
@@ -291,7 +292,7 @@ func (app *App) getSuggestedTitle(ctx context.Context, content string, originalT
 	if err != nil {
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
-	result := stripReasoning(completion.Choices[0].Content)
+	result := textsanitize.StripReasoning(completion.Choices[0].Content)
 	return strings.TrimSpace(strings.Trim(result, "\"")), nil
 }
 
@@ -347,7 +348,7 @@ func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, log
 	if err != nil {
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
-	result := stripReasoning(completion.Choices[0].Content)
+	result := textsanitize.StripReasoning(completion.Choices[0].Content)
 	return strings.TrimSpace(strings.Trim(result, "\"")), nil
 }
 
@@ -426,7 +427,7 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 		return nil, fmt.Errorf("error getting response from LLM for custom fields: %v", err)
 	}
 
-	response := stripReasoning(completion.Choices[0].Content)
+	response := textsanitize.StripReasoning(completion.Choices[0].Content)
 	response = stripMarkdown(response)
 	logger.Debugf("LLM response for custom fields: %s", response)
 
@@ -694,22 +695,6 @@ func (app *App) generateDocumentSuggestions(ctx context.Context, suggestionReque
 // getTodayDate returns the current date in YYYY-MM-DD format
 func getTodayDate() string {
 	return time.Now().Format("2006-01-02")
-}
-
-// stripReasoning removes the reasoning from the content indicated by <think> and </think> tags.
-func stripReasoning(content string) string {
-	// Remove reasoning from the content
-	reasoningStart := strings.Index(content, "<think>")
-	if reasoningStart != -1 {
-		reasoningEnd := strings.Index(content, "</think>")
-		if reasoningEnd != -1 {
-			content = content[:reasoningStart] + content[reasoningEnd+len("</think>"):]
-		}
-	}
-
-	// Trim whitespace
-	content = strings.TrimSpace(content)
-	return content
 }
 
 // stripMarkdown removes the markdown code block from the content.

--- a/app_llm_test.go
+++ b/app_llm_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"paperless-gpt/internal/textsanitize"
 	"testing"
 	"text/template"
 
@@ -331,32 +330,6 @@ func TestTokenLimitInCreatedDateGeneration(t *testing.T) {
 
 	// Final prompt should be within token limit
 	assert.LessOrEqual(t, len(tokens), 50, "Final prompt should be within token limit")
-}
-
-func TestStripReasoning(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "No reasoning tags",
-			input:    "This is a test content without reasoning tags.",
-			expected: "This is a test content without reasoning tags.",
-		},
-		{
-			name:     "Reasoning tags at the start",
-			input:    "<think>Start reasoning</think>\n\nContent      \n\n",
-			expected: "Content",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := textsanitize.StripReasoning(tc.input)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
 }
 
 // mockPaperlessClient is a mock implementation of the ClientInterface for testing.

--- a/app_llm_test.go
+++ b/app_llm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"paperless-gpt/internal/textsanitize"
 	"testing"
 	"text/template"
 
@@ -352,7 +353,7 @@ func TestStripReasoning(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := stripReasoning(tc.input)
+			result := textsanitize.StripReasoning(tc.input)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/internal/textsanitize/reasoning.go
+++ b/internal/textsanitize/reasoning.go
@@ -1,4 +1,4 @@
-package ocr
+package textsanitize
 
 import "strings"
 
@@ -7,10 +7,9 @@ const (
 	closeThinkTag = "</think>"
 )
 
-// stripReasoning removes the reasoning from the content indicated by <think> and </think> tags.
-// This is useful for models that include reasoning in their output which should be removed
-// from the final OCR text.
-func stripReasoning(content string) string {
+// StripReasoning removes reasoning content indicated by <think> and </think> tags.
+// It is resilient to malformed or dangling tags and always trims the final output.
+func StripReasoning(content string) string {
 	if content == "" {
 		return ""
 	}

--- a/internal/textsanitize/reasoning_test.go
+++ b/internal/textsanitize/reasoning_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestStripReasoning verifies reasoning-tag stripping across balanced and malformed tag patterns.
 func TestStripReasoning(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/textsanitize/reasoning_test.go
+++ b/internal/textsanitize/reasoning_test.go
@@ -1,4 +1,4 @@
-package ocr
+package textsanitize
 
 import (
 	"testing"
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestStripReasoning verifies that stripReasoning removes <think>...</think>
-// segments and handles malformed or dangling tags safely.
 func TestStripReasoning(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -68,7 +66,7 @@ func TestStripReasoning(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := stripReasoning(tc.input)
+			result := StripReasoning(tc.input)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/ocr/llm_provider.go
+++ b/ocr/llm_provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"os"
+	"paperless-gpt/internal/textsanitize"
 	"strings"
 
 	_ "image/jpeg"
@@ -162,7 +163,7 @@ func (p *LLMProvider) ProcessImage(ctx context.Context, imageContent []byte, pag
 		return nil, fmt.Errorf("error getting response from LLM: %w", err)
 	}
 
-	text := stripReasoning(completion.Choices[0].Content)
+	text := textsanitize.StripReasoning(completion.Choices[0].Content)
 	limitHit := false
 	tokenCount := -1
 

--- a/ocr/utils.go
+++ b/ocr/utils.go
@@ -2,20 +2,45 @@ package ocr
 
 import "strings"
 
+const (
+	openThinkTag  = "<think>"
+	closeThinkTag = "</think>"
+)
+
 // stripReasoning removes the reasoning from the content indicated by <think> and </think> tags.
 // This is useful for models that include reasoning in their output which should be removed
 // from the final OCR text.
 func stripReasoning(content string) string {
-	// Remove reasoning from the content
-	reasoningStart := strings.Index(content, "<think>")
-	if reasoningStart != -1 {
-		reasoningEnd := strings.Index(content, "</think>")
-		if reasoningEnd != -1 {
-			content = content[:reasoningStart] + content[reasoningEnd+len("</think>"):]
+	if content == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(content))
+
+	remaining := content
+	for len(remaining) > 0 {
+		openIdx := strings.Index(remaining, openThinkTag)
+		closeIdx := strings.Index(remaining, closeThinkTag)
+
+		switch {
+		case openIdx == -1 && closeIdx == -1:
+			builder.WriteString(remaining)
+			remaining = ""
+		case closeIdx != -1 && (openIdx == -1 || closeIdx < openIdx):
+			builder.Reset()
+			remaining = remaining[closeIdx+len(closeThinkTag):]
+		case openIdx != -1 && (closeIdx == -1 || openIdx < closeIdx):
+			builder.WriteString(remaining[:openIdx])
+			remaining = remaining[openIdx+len(openThinkTag):]
+			nextClose := strings.Index(remaining, closeThinkTag)
+			if nextClose == -1 {
+				remaining = ""
+			} else {
+				remaining = remaining[nextClose+len(closeThinkTag):]
+			}
 		}
 	}
 
-	// Trim whitespace
-	content = strings.TrimSpace(content)
-	return content
+	return strings.TrimSpace(builder.String())
 }

--- a/ocr/utils_test.go
+++ b/ocr/utils_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestStripReasoning verifies that stripReasoning removes <think>...</think>
+// segments and handles malformed or dangling tags safely.
 func TestStripReasoning(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -51,6 +53,11 @@ func TestStripReasoning(t *testing.T) {
 			name:     "Unclosed think tag",
 			input:    "Content <think>Unclosed reasoning",
 			expected: "Content",
+		},
+		{
+			name:     "Balanced tags then dangling closing tag",
+			input:    "<think>ok</think> </think> content",
+			expected: "content",
 		},
 		{
 			name:     "Dangling closing tag with trailing content",

--- a/ocr/utils_test.go
+++ b/ocr/utils_test.go
@@ -50,12 +50,12 @@ func TestStripReasoning(t *testing.T) {
 		{
 			name:     "Unclosed think tag",
 			input:    "Content <think>Unclosed reasoning",
-			expected: "Content <think>Unclosed reasoning",
+			expected: "Content",
 		},
 		{
-			name:     "Only closing tag",
-			input:    "Content </think>",
-			expected: "Content </think>",
+			name:     "Dangling closing tag with trailing content",
+			input:    "thinkingstuff </think> content",
+			expected: "content",
 		},
 	}
 


### PR DESCRIPTION
### Problem
Issue #708 added reasoning-tag stripping for OCR output, but malformed tag patterns were still not fully handled in all flows:
- Unclosed opening tag: `<think>...` with no `</think>`
- Dangling closing tag: `</think>` appearing without a valid opening tag

In addition, reasoning stripping logic existed in multiple places (OCR and app LLM paths), which risked behavior drift and inconsistent sanitization (kudos to @wickode).

This could leak reasoning artifacts into final text and produce different results depending on code path.

### What changed
- Centralized reasoning sanitization into a shared internal helper (`internal/textsanitize/StripReasoning`) as the single source of truth.
- Applied the shared sanitizer across both OCR and app LLM suggestion paths.
- Removed duplicated local OCR utility implementation and its duplicate test file after centralization.
- Removed duplicated app-local implementation and switched app tests to use the shared helper.
- Added/kept robust unit coverage for balanced and malformed <think>/</think> patterns in the shared sanitizer tests, including:
  - unclosed opening tag strips trailing reasoning content
  - dangling closing tag with trailing valid content preserves only valid content
  - balanced-tag behavior remains covered

### Before / After
**Before**
- `Content <think>Unclosed reasoning` → reasoning remnants could remain
- `thinkingstuff </think> content` → malformed output could persist

**After**
- `Content <think>Unclosed reasoning` → `Content`
- `thinkingstuff </think> content` → `content`
- OCR and app LLM flows now use identical sanitization behavior

### Testing
- Added shared sanitizer unit tests covering malformed-tag scenarios and existing balanced-tag behavior.
- Updated app test usage to validate through the shared sanitizer.
- Full test suite passes on this branch.

### Why this approach
Centralizing sanitization removes duplication and drift, ensures consistent behavior across OCR and non-OCR LLM outputs, and makes future fixes/test updates happen in one place. This gives more defensive handling for real-world model responses where reasoning tags may be malformed.

## Related issue
Fixes #914
(also follow-up context: #708)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removal of embedded reasoning markers so multiple, unclosed, or dangling markers no longer leave artifacts; trailing whitespace is trimmed and outputs are cleaner across OCR and LLM result flows.

* **Tests**
  * Updated test coverage to validate the revised stripping behavior and edge cases, ensuring more reliable outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->