### PR TITLE
Run auto-tagging only if no documents found by OCR

### DIFF
--- a/background.go
+++ b/background.go
@@ -46,11 +46,14 @@ func StartBackgroundTasks(ctx context.Context, app BackgroundProcessor) {
 				}
 
 				// Run auto-tagging after OCR
-				autoCount, err := app.processAutoTagDocuments(ctx)
-				if err != nil {
-					return 0, fmt.Errorf("error in processAutoTagDocuments: %w", err)
+				// Only run auto-tagging if OCR did not find any documents to process, otherwise re-run OCR
+				if count == 0 {
+					autoCount, err := app.processAutoTagDocuments(ctx)
+					if err != nil {
+						return 0, fmt.Errorf("error in processAutoTagDocuments: %w", err)
+					}
+					count += autoCount
 				}
-				count += autoCount
 
 				return count, nil
 			}()


### PR DESCRIPTION
### ISSUE

Currently if someone AUTO_TAG's and AUTO_OCR_TAG's some documents and then waits a short time  (ex. 15 seconds) then TAGS some more documents there is potential that the second batch of documents will not end up being OCR'd until after tagging is complete. This would be fine if LLM startup times were not potentially really slow. (I initially started hosting the Models on a HHD, which could take minutes to startup)

### SOLUTION

If OCR has processed documents, skip Tagging and check OCR again. This will recheck for new documents, 
Which in theory will keep the OCR Model alive, preventing the slow starting and stopping behavior.
Also this will help with situations where users are mass uploading files with a workflow to set the auto tag's on consumption (or using the folder tags feature).

### FLAW

If the document is processed fast enough it could potentially miss this second check.
maybe a delay could help. it would probably still be faster even with a 10-20s delay.

### TESTING

I have not tested this, as it is a relatively small feature. I also don't honestly know how the Models are started and stopped so this potentially may not even fundamentally work, but I figured regular maintainers would know that better then me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized document processing by preventing redundant auto-tagging when OCR has already successfully processed documents. Auto-tagging now runs conditionally to improve system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->