### PR TITLE
feat(ocr): add per-document prompt rendering with existing content support

### DIFF
--- a/background.go
+++ b/background.go
@@ -216,6 +216,7 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			CopyMetadata:    app.pdfCopyMetadata,
 			LimitPages:      limitOcrPages,
 			ProcessMode:     app.ocrProcessMode,
+			ExistingContent: document.Content,
 		}
 
 		// Use the DocumentProcessor interface instead of calling the method directly

--- a/default_prompts/ocr_prompt.tmpl
+++ b/default_prompts/ocr_prompt.tmpl
@@ -2,3 +2,11 @@ Just transcribe the text in this image and preserve the formatting and layout (h
 Do that for ALL the text in the image. Be thorough and pay attention. This is very important.
 The image is from a text document so be sure to continue until the bottom of the page.
 Thanks a lot! You tend to forget about some text in the image so please focus! Use markdown format but without a code block.
+{{- if .Content}}
+
+The document already has the following text extracted via basic OCR.
+Use this as a reference to help identify difficult words or numbers, but rely primarily on what you see in the image.
+Correct any errors you find in this existing text:
+
+{{.Content}}
+{{- end}}

--- a/main.go
+++ b/main.go
@@ -205,12 +205,15 @@ func main() {
 		providerType = "llm" // Default to LLM provider
 	}
 
+	// Render OCR prompt with empty Content as fallback for the provider default.
+	// Per-document rendering (with existing content) happens in ProcessDocumentOCR.
 	var promptBuffer bytes.Buffer
 	err = ocrTemplate.Execute(&promptBuffer, map[string]interface{}{
 		"Language": getLikelyLanguage(),
+		"Content":  "",
 	})
 	if err != nil {
-		log.Fatalf("error executing tag template: %v", err)
+		log.Fatalf("error executing OCR template: %v", err)
 	}
 
 	ocrPrompt := promptBuffer.String()

--- a/ocr.go
+++ b/ocr.go
@@ -54,6 +54,16 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	}
 	docLogger.Info("Starting OCR processing")
 
+	// Render OCR prompt per-document with existing content (same pattern as title/tag/etc. prompts)
+	ocrPrompt, err := renderOCRPrompt(options.ExistingContent)
+	if err != nil {
+		docLogger.WithError(err).Warn("Failed to render per-document OCR prompt, using provider default")
+	} else if ocrPrompt != "" {
+		if llmProv, ok := app.ocrProvider.(*ocr.LLMProvider); ok {
+			llmProv.SetPrompt(ocrPrompt)
+		}
+	}
+
 	// Determine the actual process mode to use
 	processMode := options.ProcessMode
 	if processMode == "" {

--- a/ocr.go
+++ b/ocr.go
@@ -60,10 +60,8 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	ocrPrompt, err := renderOCRPrompt(options.ExistingContent)
 	if err != nil {
 		docLogger.WithError(err).Warn("Failed to render per-document OCR prompt, using provider default")
-	} else if ocrPrompt != "" {
-		if llmProv, ok := provider.(*ocr.LLMProvider); ok {
-			provider = llmProv.WithPrompt(ocrPrompt)
-		}
+	} else if llmProv, ok := provider.(*ocr.LLMProvider); ok {
+		provider = llmProv.WithPrompt(ocrPrompt)
 	}
 
 	// Determine the actual process mode to use

--- a/ocr.go
+++ b/ocr.go
@@ -54,13 +54,15 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	}
 	docLogger.Info("Starting OCR processing")
 
-	// Render OCR prompt per-document with existing content (same pattern as title/tag/etc. prompts)
+	// Render OCR prompt per-document with existing content (same pattern as title/tag/etc. prompts).
+	// Use a call-scoped provider clone to avoid mutating the shared singleton.
+	provider := app.ocrProvider
 	ocrPrompt, err := renderOCRPrompt(options.ExistingContent)
 	if err != nil {
 		docLogger.WithError(err).Warn("Failed to render per-document OCR prompt, using provider default")
 	} else if ocrPrompt != "" {
-		if llmProv, ok := app.ocrProvider.(*ocr.LLMProvider); ok {
-			llmProv.SetPrompt(ocrPrompt)
+		if llmProv, ok := provider.(*ocr.LLMProvider); ok {
+			provider = llmProv.WithPrompt(ocrPrompt)
 		}
 	}
 
@@ -125,7 +127,7 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	var hocrCapable HOCRCapable
 	var hasHOCR bool
 
-	hocrCapable, hasHOCR = app.ocrProvider.(HOCRCapable)
+	hocrCapable, hasHOCR = provider.(HOCRCapable)
 
 	// Reset hOCR if the provider supports it
 	if hasHOCR {
@@ -171,7 +173,7 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 		}).Debug("Processing whole PDF document")
 
 		// Process the whole PDF in one go
-		result, err := app.ocrProvider.ProcessImage(ctx, originalPDFData, 0) // Page 0 indicates entire document
+		result, err := provider.ProcessImage(ctx, originalPDFData, 0) // Page 0 indicates entire document
 		if err != nil {
 			return nil, fmt.Errorf("error performing OCR for document %d: %w", documentID, err)
 		}
@@ -229,7 +231,7 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 			}
 
 			// Pass the page number (1-based index) to ProcessImage
-			result, err := app.ocrProvider.ProcessImage(ctx, pdfContent, i+1)
+			result, err := provider.ProcessImage(ctx, pdfContent, i+1)
 			if err != nil {
 				return nil, fmt.Errorf("error performing OCR for document %d, page %d: %w", documentID, i+1, err)
 			}
@@ -299,7 +301,7 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 			imageDataList = append(imageDataList, imageContent)
 
 			// Pass the page number (1-based index) to ProcessImage
-			result, err := app.ocrProvider.ProcessImage(ctx, imageContent, i+1)
+			result, err := provider.ProcessImage(ctx, imageContent, i+1)
 			if err != nil {
 				return nil, fmt.Errorf("error performing OCR for document %d, page %d: %w", documentID, i+1, err)
 			}

--- a/ocr/llm_provider.go
+++ b/ocr/llm_provider.go
@@ -31,11 +31,12 @@ type LLMProvider struct {
 	ollamaTopK  *int
 }
 
-// SetPrompt overrides the OCR prompt for subsequent ProcessImage calls.
-// This enables per-document prompt rendering where the template can include
-// document-specific data like existing OCR text.
-func (p *LLMProvider) SetPrompt(prompt string) {
-	p.prompt = prompt
+// WithPrompt returns a shallow copy of the provider with a different prompt.
+// This enables per-document prompt rendering without mutating shared state.
+func (p *LLMProvider) WithPrompt(prompt string) *LLMProvider {
+	clone := *p
+	clone.prompt = prompt
+	return &clone
 }
 
 // GetPrompt returns the current OCR prompt.

--- a/ocr/llm_provider.go
+++ b/ocr/llm_provider.go
@@ -123,7 +123,7 @@ func (p *LLMProvider) ProcessImage(ctx context.Context, imageContent []byte, pag
 		}).Debug("Image dimensions")
 	}
 
-	logger.Debugf("Prompt: %s", p.prompt)
+	logger.Debugf("Prompt length: %d", len(p.prompt))
 
 	// Prepare content parts based on provider type
 	var parts []llms.ContentPart

--- a/ocr/llm_provider.go
+++ b/ocr/llm_provider.go
@@ -31,6 +31,18 @@ type LLMProvider struct {
 	ollamaTopK  *int
 }
 
+// SetPrompt overrides the OCR prompt for subsequent ProcessImage calls.
+// This enables per-document prompt rendering where the template can include
+// document-specific data like existing OCR text.
+func (p *LLMProvider) SetPrompt(prompt string) {
+	p.prompt = prompt
+}
+
+// GetPrompt returns the current OCR prompt.
+func (p *LLMProvider) GetPrompt() string {
+	return p.prompt
+}
+
 func newLLMProvider(config Config) (*LLMProvider, error) {
 	logger := log.WithFields(logrus.Fields{
 		"provider": config.VisionLLMProvider,

--- a/ocr/llm_provider_prompt_test.go
+++ b/ocr/llm_provider_prompt_test.go
@@ -6,23 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLLMProvider_SetPrompt(t *testing.T) {
-	provider := &LLMProvider{
+func TestLLMProvider_WithPrompt(t *testing.T) {
+	original := &LLMProvider{
 		prompt: "default prompt",
 	}
 
-	assert.Equal(t, "default prompt", provider.GetPrompt())
-
-	provider.SetPrompt("custom per-document prompt")
-	assert.Equal(t, "custom per-document prompt", provider.GetPrompt())
+	clone := original.WithPrompt("custom per-document prompt")
+	assert.Equal(t, "custom per-document prompt", clone.GetPrompt())
+	// Original is not mutated
+	assert.Equal(t, "default prompt", original.GetPrompt())
 }
 
-func TestLLMProvider_SetPrompt_Empty(t *testing.T) {
-	provider := &LLMProvider{
+func TestLLMProvider_WithPrompt_Empty(t *testing.T) {
+	original := &LLMProvider{
 		prompt: "default prompt",
 	}
 
-	// Setting empty string should still work (caller's responsibility)
-	provider.SetPrompt("")
-	assert.Equal(t, "", provider.GetPrompt())
+	clone := original.WithPrompt("")
+	assert.Equal(t, "", clone.GetPrompt())
+	assert.Equal(t, "default prompt", original.GetPrompt())
 }

--- a/ocr/llm_provider_prompt_test.go
+++ b/ocr/llm_provider_prompt_test.go
@@ -1,0 +1,28 @@
+package ocr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLLMProvider_SetPrompt(t *testing.T) {
+	provider := &LLMProvider{
+		prompt: "default prompt",
+	}
+
+	assert.Equal(t, "default prompt", provider.GetPrompt())
+
+	provider.SetPrompt("custom per-document prompt")
+	assert.Equal(t, "custom per-document prompt", provider.GetPrompt())
+}
+
+func TestLLMProvider_SetPrompt_Empty(t *testing.T) {
+	provider := &LLMProvider{
+		prompt: "default prompt",
+	}
+
+	// Setting empty string should still work (caller's responsibility)
+	provider.SetPrompt("")
+	assert.Equal(t, "", provider.GetPrompt())
+}

--- a/ocr_prompt.go
+++ b/ocr_prompt.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// renderOCRPrompt renders the OCR template with per-document data.
+// This follows the same pattern as getSuggestedTitle, getSuggestedTags, etc.
+// which all render their templates per-document with the document's content.
+func renderOCRPrompt(existingContent string) (string, error) {
+	templateMutex.RLock()
+	defer templateMutex.RUnlock()
+
+	var buf bytes.Buffer
+	err := ocrTemplate.Execute(&buf, map[string]interface{}{
+		"Language": getLikelyLanguage(),
+		"Content":  existingContent,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error executing OCR template: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/ocr_prompt.go
+++ b/ocr_prompt.go
@@ -5,10 +5,19 @@ import (
 	"fmt"
 )
 
+// maxOCRExistingContentLen caps the existing-content reference injected into the
+// OCR prompt. Vision model context is shared with image tokens, so we keep
+// this modest. 8000 chars ≈ 2000 tokens — plenty for cross-referencing.
+const maxOCRExistingContentLen = 8000
+
 // renderOCRPrompt renders the OCR template with per-document data.
 // This follows the same pattern as getSuggestedTitle, getSuggestedTags, etc.
 // which all render their templates per-document with the document's content.
 func renderOCRPrompt(existingContent string) (string, error) {
+	if len(existingContent) > maxOCRExistingContentLen {
+		existingContent = existingContent[:maxOCRExistingContentLen]
+	}
+
 	templateMutex.RLock()
 	defer templateMutex.RUnlock()
 

--- a/ocr_prompt_test.go
+++ b/ocr_prompt_test.go
@@ -52,6 +52,8 @@ func TestRenderOCRPrompt_WithoutContent(t *testing.T) {
 }
 
 func TestRenderOCRPrompt_LanguageIncluded(t *testing.T) {
+	t.Setenv("LLM_LANGUAGE", "German")
+
 	tmpl, err := template.New("test").Funcs(sprig.FuncMap()).Parse(
 		`Language: {{.Language}}`)
 	require.NoError(t, err)
@@ -68,6 +70,5 @@ func TestRenderOCRPrompt_LanguageIncluded(t *testing.T) {
 
 	result, err := renderOCRPrompt("")
 	require.NoError(t, err)
-	// getLikelyLanguage() defaults to "English" when LLM_LANGUAGE is unset
-	assert.Contains(t, result, "Language:")
+	assert.Equal(t, "Language: German", result)
 }

--- a/ocr_prompt_test.go
+++ b/ocr_prompt_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderOCRPrompt_WithContent(t *testing.T) {
+	tmpl, err := template.New("test").Funcs(sprig.FuncMap()).Parse(
+		`OCR this.{{- if .Content}} Existing text: {{.Content}}{{- end}}`)
+	require.NoError(t, err)
+
+	templateMutex.Lock()
+	origTemplate := ocrTemplate
+	ocrTemplate = tmpl
+	templateMutex.Unlock()
+	defer func() {
+		templateMutex.Lock()
+		ocrTemplate = origTemplate
+		templateMutex.Unlock()
+	}()
+
+	result, err := renderOCRPrompt("existing tesseract text")
+	require.NoError(t, err)
+	assert.Contains(t, result, "existing tesseract text")
+	assert.Contains(t, result, "OCR this.")
+}
+
+func TestRenderOCRPrompt_WithoutContent(t *testing.T) {
+	tmpl, err := template.New("test").Funcs(sprig.FuncMap()).Parse(
+		`OCR this.{{- if .Content}} Existing text: {{.Content}}{{- end}}`)
+	require.NoError(t, err)
+
+	templateMutex.Lock()
+	origTemplate := ocrTemplate
+	ocrTemplate = tmpl
+	templateMutex.Unlock()
+	defer func() {
+		templateMutex.Lock()
+		ocrTemplate = origTemplate
+		templateMutex.Unlock()
+	}()
+
+	result, err := renderOCRPrompt("")
+	require.NoError(t, err)
+	assert.Equal(t, "OCR this.", result)
+	assert.NotContains(t, result, "Existing text")
+}
+
+func TestRenderOCRPrompt_LanguageIncluded(t *testing.T) {
+	tmpl, err := template.New("test").Funcs(sprig.FuncMap()).Parse(
+		`Language: {{.Language}}`)
+	require.NoError(t, err)
+
+	templateMutex.Lock()
+	origTemplate := ocrTemplate
+	ocrTemplate = tmpl
+	templateMutex.Unlock()
+	defer func() {
+		templateMutex.Lock()
+		ocrTemplate = origTemplate
+		templateMutex.Unlock()
+	}()
+
+	result, err := renderOCRPrompt("")
+	require.NoError(t, err)
+	// getLikelyLanguage() defaults to "English" when LLM_LANGUAGE is unset
+	assert.Contains(t, result, "Language:")
+}

--- a/types.go
+++ b/types.go
@@ -154,6 +154,7 @@ type OCROptions struct {
 	CopyMetadata    bool   // Whether to copy metadata from the original document
 	LimitPages      int    // Limit on the number of pages to process (0 = no limit)
 	ProcessMode     string // OCR processing mode: "image" (default) or "pdf"
+	ExistingContent string // Existing document text (e.g., from Tesseract) to include in OCR prompt
 }
 
 // ClientInterface defines the interface for PaperlessClient operations


### PR DESCRIPTION
## Summary

Allows the OCR prompt template to reference a document's existing text (e.g., Tesseract output) via `{{.Content}}`. This helps vision models cross-reference basic OCR when transcribing difficult words or numbers.

### Changes
- **Per-document prompt rendering**: OCR template is now rendered per-document (matching the pattern used by title, tag, correspondent, and all other prompts) instead of once at startup
- **`SetPrompt`/`GetPrompt` on `LLMProvider`**: Enables per-document prompt overrides without changing the `Provider` interface
- **`ExistingContent` in `OCROptions`**: Callers pass existing document text, which flows into the template as `{{.Content}}`
- **Updated default template**: Conditionally includes existing text as reference material for the vision model

### How it works

The OCR prompt template already supported `{{.Language}}`. This adds `{{.Content}}` following the exact same per-document rendering pattern used by every other prompt template (`title_prompt.tmpl`, `tag_prompt.tmpl`, etc.).

The default template adds a conditional block:
```
{{- if .Content}}
The document already has the following text extracted via basic OCR.
Use this as a reference to help identify difficult words or numbers,
but rely primarily on what you see in the image.
{{.Content}}
{{- end}}
```

### Backward Compatibility
- Templates without `{{.Content}}` work identically to before
- A static fallback prompt (rendered without Content at startup) ensures the LLM provider has a default
- Non-LLM providers (Azure, Google DocAI, Mistral OCR, Docling) are unaffected
- Users with custom prompts opt in by adding `{{.Content}}` to their template

Closes #882

## Test Plan
- [x] Unit tests for `SetPrompt`/`GetPrompt` on LLMProvider
- [x] Unit tests for `renderOCRPrompt` with and without content
- [x] Existing test suite passes unchanged
- [x] `go vet ./...` clean
- [ ] Manual test: OCR a document with existing Tesseract text, verify prompt includes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCR now surfaces previously extracted text so users can review and correct it before re-processing.
  * Prompts are rendered per-document and include detected language for clearer, context-aware OCR guidance.

* **Tests**
  * Added tests to validate per-document prompt rendering and prompt-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->