### PR TITLE
fix: skip failed OCR pages instead of aborting entire document

### DIFF
--- a/background.go
+++ b/background.go
@@ -261,16 +261,6 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			OriginalDocument: document,
 			SuggestedContent: processedDoc.Text,
 			RemoveTags:       removeTags,
-			// Add appropriate tag based on whether OCR was complete or partial
-			AddTags: func() []string {
-				if !app.pdfOCRTagging || options.UploadPDF {
-					return nil
-				}
-				if isPartial {
-					return []string{app.pdfOCRPartialTag}
-				}
-				return []string{app.pdfOCRCompleteTag}
-			}(),
 		}
 
 		if app.pdfOCRTagging {

--- a/background.go
+++ b/background.go
@@ -244,25 +244,35 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			docLogger.Debug("OCR processing completed")
 		}
 
+		isPartial := len(processedDoc.SkippedPages) > 0
+
 		documentSuggestion := DocumentSuggestion{
 			ID:               document.ID,
 			OriginalDocument: document,
 			SuggestedContent: processedDoc.Text,
 			RemoveTags:       []string{autoOcrTag},
-			// Add OCR complete tag if tagging is enabled and PDF wasn't uploaded (upload handles tagging)
+			// Add appropriate tag based on whether OCR was complete or partial
 			AddTags: func() []string {
-				if app.pdfOCRTagging && !options.UploadPDF {
-					return []string{app.pdfOCRCompleteTag}
+				if !app.pdfOCRTagging || options.UploadPDF {
+					return nil
 				}
-				return nil
+				if isPartial {
+					return []string{app.pdfOCRPartialTag}
+				}
+				return []string{app.pdfOCRCompleteTag}
 			}(),
 		}
 
-		if (app.pdfOCRTagging) && app.pdfOCRCompleteTag != "" {
-			// Add the OCR complete tag if tagging is enabled
-			documentSuggestion.SuggestedTags = []string{app.pdfOCRCompleteTag}
-			documentSuggestion.KeepOriginalTags = true
-			docLogger.Infof("Adding OCR complete tag '%s'", app.pdfOCRCompleteTag)
+		if app.pdfOCRTagging {
+			if isPartial && app.pdfOCRPartialTag != "" {
+				documentSuggestion.SuggestedTags = []string{app.pdfOCRPartialTag}
+				documentSuggestion.KeepOriginalTags = true
+				docLogger.Warnf("Adding OCR partial tag '%s' (skipped pages: %v)", app.pdfOCRPartialTag, processedDoc.SkippedPages)
+			} else if !isPartial && app.pdfOCRCompleteTag != "" {
+				documentSuggestion.SuggestedTags = []string{app.pdfOCRCompleteTag}
+				documentSuggestion.KeepOriginalTags = true
+				docLogger.Infof("Adding OCR complete tag '%s'", app.pdfOCRCompleteTag)
+			}
 		}
 
 		// Skip updating the original document if it was actually replaced (deleted) during OCR.

--- a/background.go
+++ b/background.go
@@ -249,7 +249,8 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			docLogger.Debug("OCR processing completed")
 		}
 
-		isPartial := len(processedDoc.SkippedPages) > 0 || processedDoc.PagesAttempted < processedDoc.TotalPages
+		isPartial := len(processedDoc.SkippedPages) > 0 ||
+			(processedDoc.TotalPages > 0 && processedDoc.PagesAttempted < processedDoc.TotalPages)
 
 		// Build remove-tags list: always remove autoOcrTag,
 		// and clear the stale partial tag on full success

--- a/background.go
+++ b/background.go
@@ -188,13 +188,16 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			if hasCompleteTag {
 				docLogger.Infof("Document already has OCR complete tag '%s', skipping OCR processing", app.pdfOCRCompleteTag)
 
-				// Remove only the autoOcrTag to take it out of the processing queue
-				// while preserving the OCR complete tag
+				// Remove autoOcrTag and any stale partial tag
+				skipRemoveTags := []string{autoOcrTag}
+				if app.pdfOCRPartialTag != "" {
+					skipRemoveTags = append(skipRemoveTags, app.pdfOCRPartialTag)
+				}
 				err = app.Client.UpdateDocuments(ctx, []DocumentSuggestion{
 					{
 						ID:               document.ID,
 						OriginalDocument: document,
-						RemoveTags:       []string{autoOcrTag},
+						RemoveTags:       skipRemoveTags,
 					},
 				}, app.Database, false)
 
@@ -246,11 +249,18 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 
 		isPartial := len(processedDoc.SkippedPages) > 0
 
+		// Build remove-tags list: always remove autoOcrTag,
+		// and clear the stale partial tag on full success
+		removeTags := []string{autoOcrTag}
+		if !isPartial && app.pdfOCRPartialTag != "" {
+			removeTags = append(removeTags, app.pdfOCRPartialTag)
+		}
+
 		documentSuggestion := DocumentSuggestion{
 			ID:               document.ID,
 			OriginalDocument: document,
 			SuggestedContent: processedDoc.Text,
-			RemoveTags:       []string{autoOcrTag},
+			RemoveTags:       removeTags,
 			// Add appropriate tag based on whether OCR was complete or partial
 			AddTags: func() []string {
 				if !app.pdfOCRTagging || options.UploadPDF {

--- a/background.go
+++ b/background.go
@@ -243,11 +243,13 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 		}
 		if len(processedDoc.SkippedPages) > 0 {
 			docLogger.Warnf("OCR partially completed, skipped pages: %v", processedDoc.SkippedPages)
+		} else if processedDoc.PagesAttempted < processedDoc.TotalPages {
+			docLogger.Warnf("OCR partially completed, processed %d of %d pages (page limit)", processedDoc.PagesAttempted, processedDoc.TotalPages)
 		} else {
 			docLogger.Debug("OCR processing completed")
 		}
 
-		isPartial := len(processedDoc.SkippedPages) > 0
+		isPartial := len(processedDoc.SkippedPages) > 0 || processedDoc.PagesAttempted < processedDoc.TotalPages
 
 		// Build remove-tags list: always remove autoOcrTag,
 		// and clear the stale partial tag on full success

--- a/background.go
+++ b/background.go
@@ -238,7 +238,11 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 			docLogger.Info("OCR processing skipped for document")
 			continue
 		}
-		docLogger.Debug("OCR processing completed")
+		if len(processedDoc.SkippedPages) > 0 {
+			docLogger.Warnf("OCR partially completed, skipped pages: %v", processedDoc.SkippedPages)
+		} else {
+			docLogger.Debug("OCR processing completed")
+		}
 
 		documentSuggestion := DocumentSuggestion{
 			ID:               document.ID,

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ var (
 	pdfReplace                    = os.Getenv("PDF_REPLACE") == "true"
 	pdfCopyMetadata               = os.Getenv("PDF_COPY_METADATA") == "true"
 	pdfOCRCompleteTag             = os.Getenv("PDF_OCR_COMPLETE_TAG")
+	pdfOCRPartialTag              = os.Getenv("OCR_PARTIAL_ERROR_TAG")
 	pdfOCRTagging                 = os.Getenv("PDF_OCR_TAGGING") == "true"
 	pdfSkipExistingOCR            = os.Getenv("PDF_SKIP_EXISTING_OCR") == "true"
 	doclingURL                    = os.Getenv("DOCLING_URL")
@@ -134,6 +135,7 @@ type App struct {
 	pdfReplace         bool              // Whether to replace original document after upload
 	pdfCopyMetadata    bool              // Whether to copy metadata from original to uploaded PDF
 	pdfOCRCompleteTag  string            // Tag to add to documents that have been OCR processed
+	pdfOCRPartialTag   string            // Tag to add to documents with partial OCR (some pages failed)
 	pdfOCRTagging      bool              // Whether to add the OCR complete tag to processed PDFs
 	pdfSkipExistingOCR bool              // Whether to skip processing PDFs that already have OCR detected
 }
@@ -333,6 +335,7 @@ func main() {
 		pdfReplace:         pdfReplace,
 		pdfCopyMetadata:    pdfCopyMetadata,
 		pdfOCRCompleteTag:  pdfOCRCompleteTag,
+		pdfOCRPartialTag:   pdfOCRPartialTag,
 		pdfOCRTagging:      pdfOCRTagging,
 		pdfSkipExistingOCR: pdfSkipExistingOCR,
 	}
@@ -583,6 +586,10 @@ func validateOrDefaultEnvVars() {
 
 	if pdfOCRCompleteTag == "" {
 		pdfOCRCompleteTag = "paperless-gpt-ocr-complete"
+	}
+
+	if pdfOCRPartialTag == "" {
+		pdfOCRPartialTag = "paperless-gpt-ocr-incomplete"
 	}
 
 	if paperlessBaseURL == "" {

--- a/ocr.go
+++ b/ocr.go
@@ -25,6 +25,8 @@ type ProcessedDocument struct {
 	PDFData          []byte
 	ReplacedOriginal bool  // true when the original document was successfully deleted and replaced
 	SkippedPages     []int // pages that failed OCR and were skipped
+	TotalPages       int   // total pages in the original document
+	PagesAttempted   int   // pages that were actually downloaded and attempted
 }
 
 // HOCRCapable defines an interface for OCR providers that can generate hOCR
@@ -358,11 +360,21 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 
 	fullText := strings.Join(ocrTexts, "\n\n")
 
+	// Determine pages attempted based on process mode
+	var pagesAttempted int
+	if processMode == "whole_pdf" {
+		pagesAttempted = totalPdfPages
+	} else {
+		pagesAttempted = len(ocrTexts) + len(skippedPages)
+	}
+
 	// Create ProcessedDocument to hold all the results
 	processedDoc := &ProcessedDocument{
-		ID:           documentID,
-		Text:         fullText,
-		SkippedPages: skippedPages,
+		ID:             documentID,
+		Text:           fullText,
+		SkippedPages:   skippedPages,
+		TotalPages:     totalPdfPages,
+		PagesAttempted: pagesAttempted,
 	}
 
 	// Generate complete hOCR if we have hOCR capability

--- a/ocr.go
+++ b/ocr.go
@@ -294,11 +294,17 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 			if err != nil {
 				pageLogger.Warnf("OCR failed for page, skipping: %v", err)
 				skippedPages = append(skippedPages, i+1)
+				if jobID != "" {
+					jobStore.updatePagesDone(jobID, i+1)
+				}
 				continue
 			}
 			if result == nil {
 				pageLogger.Warn("Got nil result from OCR provider, skipping page")
 				skippedPages = append(skippedPages, i+1)
+				if jobID != "" {
+					jobStore.updatePagesDone(jobID, i+1)
+				}
 				continue
 			}
 

--- a/ocr.go
+++ b/ocr.go
@@ -238,6 +238,10 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 				continue
 			}
 
+			if jobID != "" {
+				jobStore.updatePagesDone(jobID, i+1)
+			}
+
 			pageLogger.WithField("has_hocr_page", result.HOCRPage != nil).
 				WithField("metadata", result.Metadata).
 				Debug("OCR completed for page")

--- a/ocr.go
+++ b/ocr.go
@@ -377,6 +377,9 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 				// Apply OCR to PDF if the feature is enabled
 				if app.createLocalPDF && app.localPDFPath != "" {
 					processedPageCount := len(ocrTexts)
+					if processMode == "whole_pdf" {
+						processedPageCount = totalPdfPages
+					}
 
 					// SAFETY CHECK: Don't generate PDF if we're processing fewer pages than original document
 					if processedPageCount != totalPdfPages {

--- a/ocr.go
+++ b/ocr.go
@@ -23,7 +23,8 @@ type ProcessedDocument struct {
 	HOCRStruct       *hocr.HOCR
 	HOCR             string
 	PDFData          []byte
-	ReplacedOriginal bool // true when the original document was successfully deleted and replaced
+	ReplacedOriginal bool  // true when the original document was successfully deleted and replaced
+	SkippedPages     []int // pages that failed OCR and were skipped
 }
 
 // HOCRCapable defines an interface for OCR providers that can generate hOCR
@@ -136,6 +137,7 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	var totalPdfPages int
 	var imagePaths []string
 	var ocrResults []*ocr.OCRResult
+	var skippedPages []int
 
 	// Default process mode to app's ocrProcessMode if not set in options
 	processMode = options.ProcessMode
@@ -221,11 +223,14 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 			// Pass the page number (1-based index) to ProcessImage
 			result, err := app.ocrProvider.ProcessImage(ctx, pdfContent, i+1)
 			if err != nil {
-				return nil, fmt.Errorf("error performing OCR for document %d, page %d: %w", documentID, i+1, err)
+				pageLogger.Warnf("OCR failed for page, skipping: %v", err)
+				skippedPages = append(skippedPages, i+1)
+				continue
 			}
 			if result == nil {
-				pageLogger.Error("Got nil result from OCR provider")
-				return nil, fmt.Errorf("error performing OCR for document %d, page %d: nil result", documentID, i+1)
+				pageLogger.Warn("Got nil result from OCR provider, skipping page")
+				skippedPages = append(skippedPages, i+1)
+				continue
 			}
 
 			pageLogger.WithField("has_hocr_page", result.HOCRPage != nil).
@@ -291,11 +296,14 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 			// Pass the page number (1-based index) to ProcessImage
 			result, err := app.ocrProvider.ProcessImage(ctx, imageContent, i+1)
 			if err != nil {
-				return nil, fmt.Errorf("error performing OCR for document %d, page %d: %w", documentID, i+1, err)
+				pageLogger.Warnf("OCR failed for page, skipping: %v", err)
+				skippedPages = append(skippedPages, i+1)
+				continue
 			}
 			if result == nil {
-				pageLogger.Error("Got nil result from OCR provider")
-				return nil, fmt.Errorf("error performing OCR for document %d, page %d: nil result", documentID, i+1)
+				pageLogger.Warn("Got nil result from OCR provider, skipping page")
+				skippedPages = append(skippedPages, i+1)
+				continue
 			}
 
 			if jobID != "" {
@@ -324,12 +332,22 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 		}
 	}
 
+	// If all pages failed OCR, return an error
+	if len(ocrTexts) == 0 && len(skippedPages) > 0 {
+		return nil, fmt.Errorf("OCR failed on all %d pages for document %d", len(skippedPages), documentID)
+	}
+
+	if len(skippedPages) > 0 {
+		docLogger.Warnf("OCR skipped %d pages: %v", len(skippedPages), skippedPages)
+	}
+
 	fullText := strings.Join(ocrTexts, "\n\n")
 
 	// Create ProcessedDocument to hold all the results
 	processedDoc := &ProcessedDocument{
-		ID:   documentID,
-		Text: fullText,
+		ID:           documentID,
+		Text:         fullText,
+		SkippedPages: skippedPages,
 	}
 
 	// Generate complete hOCR if we have hOCR capability

--- a/ocr.go
+++ b/ocr.go
@@ -224,11 +224,17 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 			if err != nil {
 				pageLogger.Warnf("OCR failed for page, skipping: %v", err)
 				skippedPages = append(skippedPages, i+1)
+				if jobID != "" {
+					jobStore.updatePagesDone(jobID, i+1)
+				}
 				continue
 			}
 			if result == nil {
 				pageLogger.Warn("Got nil result from OCR provider, skipping page")
 				skippedPages = append(skippedPages, i+1)
+				if jobID != "" {
+					jobStore.updatePagesDone(jobID, i+1)
+				}
 				continue
 			}
 

--- a/ocr.go
+++ b/ocr.go
@@ -135,7 +135,6 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 	var imageDataList [][]byte
 	var originalPDFData []byte
 	var totalPdfPages int
-	var imagePaths []string
 	var ocrResults []*ocr.OCRResult
 	var skippedPages []int
 
@@ -290,9 +289,6 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 				return nil, fmt.Errorf("error reading image file for document %d, page %d: %w", documentID, i+1, err)
 			}
 
-			// Store image data for potential PDF generation
-			imageDataList = append(imageDataList, imageContent)
-
 			// Pass the page number (1-based index) to ProcessImage
 			result, err := app.ocrProvider.ProcessImage(ctx, imageContent, i+1)
 			if err != nil {
@@ -305,6 +301,9 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 				skippedPages = append(skippedPages, i+1)
 				continue
 			}
+
+			// Store image data only for successfully processed pages
+			imageDataList = append(imageDataList, imageContent)
 
 			if jobID != "" {
 				jobStore.updatePagesDone(jobID, i+1)
@@ -377,12 +376,7 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 
 				// Apply OCR to PDF if the feature is enabled
 				if app.createLocalPDF && app.localPDFPath != "" {
-					var processedPageCount int
-					if processMode == "pdf" || processMode == "whole_pdf" {
-						processedPageCount = len(ocrTexts)
-					} else {
-						processedPageCount = len(imagePaths)
-					}
+					processedPageCount := len(ocrTexts)
 
 					// SAFETY CHECK: Don't generate PDF if we're processing fewer pages than original document
 					if processedPageCount != totalPdfPages {

--- a/ocr_test.go
+++ b/ocr_test.go
@@ -401,6 +401,7 @@ func TestProcessDocumentOCR_PartialPageFailure(t *testing.T) {
 
 	result, err := app.ProcessDocumentOCR(context.Background(), 1, OCROptions{}, "")
 	require.NoError(t, err)
+	require.NotNil(t, result)
 
 	assert.Equal(t, []int{2}, result.SkippedPages)
 	assert.Contains(t, result.Text, "text from page 1")
@@ -425,8 +426,8 @@ func TestProcessDocumentOCR_AllPagesFail(t *testing.T) {
 	}
 
 	result, err := app.ProcessDocumentOCR(context.Background(), 1, OCROptions{}, "")
-	assert.Nil(t, result)
-	assert.Error(t, err)
+	require.Nil(t, result)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OCR failed on all 2 pages")
 }
 

--- a/ocr_test.go
+++ b/ocr_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"paperless-gpt/ocr"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -347,6 +349,87 @@ func TestOCROptionsValidation(t *testing.T) {
 	}
 }
 
+// pageFailingOCRProvider fails OCR on specific pages (1-based)
+type pageFailingOCRProvider struct {
+	failPages map[int]bool
+}
+
+func (p *pageFailingOCRProvider) ProcessImage(ctx context.Context, imageContent []byte, pageNumber int) (*ocr.OCRResult, error) {
+	if p.failPages[pageNumber] {
+		return nil, fmt.Errorf("OCR engine error on page %d", pageNumber)
+	}
+	return &ocr.OCRResult{
+		Text: fmt.Sprintf("text from page %d", pageNumber),
+	}, nil
+}
+
+// ocrTestClientStub implements ClientInterface for OCR skip-page tests.
+// It creates real temp files so os.ReadFile works inside ProcessDocumentOCR.
+type ocrTestClientStub struct {
+	mockPaperlessClient
+	tmpDir    string
+	pageCount int
+}
+
+func (c *ocrTestClientStub) DownloadDocumentAsImages(ctx context.Context, documentID int, pageLimit int) ([]string, int, error) {
+	var paths []string
+	for i := 0; i < c.pageCount; i++ {
+		p := filepath.Join(c.tmpDir, fmt.Sprintf("page_%d.png", i))
+		if err := os.WriteFile(p, []byte(fmt.Sprintf("img%d", i)), 0644); err != nil {
+			return nil, 0, err
+		}
+		paths = append(paths, p)
+	}
+	return paths, c.pageCount, nil
+}
+
+func TestProcessDocumentOCR_PartialPageFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	db, err := InitializeTestDB()
+	require.NoError(t, err)
+
+	client := &ocrTestClientStub{tmpDir: tmpDir, pageCount: 3}
+	provider := &pageFailingOCRProvider{failPages: map[int]bool{2: true}} // page 2 fails
+
+	app := &App{
+		Client:         client,
+		Database:       db,
+		ocrProvider:    provider,
+		ocrProcessMode: "image",
+	}
+
+	result, err := app.ProcessDocumentOCR(context.Background(), 1, OCROptions{}, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{2}, result.SkippedPages)
+	assert.Contains(t, result.Text, "text from page 1")
+	assert.Contains(t, result.Text, "text from page 3")
+	assert.NotContains(t, result.Text, "text from page 2")
+}
+
+func TestProcessDocumentOCR_AllPagesFail(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	db, err := InitializeTestDB()
+	require.NoError(t, err)
+
+	client := &ocrTestClientStub{tmpDir: tmpDir, pageCount: 2}
+	provider := &pageFailingOCRProvider{failPages: map[int]bool{1: true, 2: true}}
+
+	app := &App{
+		Client:         client,
+		Database:       db,
+		ocrProvider:    provider,
+		ocrProcessMode: "image",
+	}
+
+	result, err := app.ProcessDocumentOCR(context.Background(), 1, OCROptions{}, "")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "OCR failed on all 2 pages")
+}
+
 func TestOCRDetectionBehavior(t *testing.T) {
 	testCases := []struct {
 		name               string
@@ -396,8 +479,8 @@ func TestOCRDetectionBehavior(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a test environment with controlled PDF processing
 			mockApp := &App{
-			    ocrProcessMode:     tc.ocrMode,
-			    pdfSkipExistingOCR: tc.pdfSkipExistingOCR,
+				ocrProcessMode:     tc.ocrMode,
+				pdfSkipExistingOCR: tc.pdfSkipExistingOCR,
 			}
 
 			// Mock the pdfocr.DetectOCR function using monkey patching or a test stub
@@ -406,21 +489,21 @@ func TestOCRDetectionBehavior(t *testing.T) {
 			// Override the relevant conditional check to track if OCR detection would be performed
 			// This is a simplified way to test the behavior without actually processing PDFs
 			shouldCheck := false
-			
+
 			if mockApp.pdfSkipExistingOCR && (tc.ocrMode == "pdf" || tc.ocrMode == "whole_pdf") {
-			    shouldCheck = true
-			    ocrDetectionCalled = true
+				shouldCheck = true
+				ocrDetectionCalled = true
 			}
 
 			// Verify the OCR detection behavior
-			assert.Equal(t, tc.shouldCheckOCR, shouldCheck, 
-			    "OCR detection behavior doesn't match expected for mode=%s, skipExistingOCR=%v", 
-			    tc.ocrMode, tc.pdfSkipExistingOCR)
-			
+			assert.Equal(t, tc.shouldCheckOCR, shouldCheck,
+				"OCR detection behavior doesn't match expected for mode=%s, skipExistingOCR=%v",
+				tc.ocrMode, tc.pdfSkipExistingOCR)
+
 			if tc.shouldCheckOCR {
-			    assert.True(t, ocrDetectionCalled, "OCR detection should be performed")
+				assert.True(t, ocrDetectionCalled, "OCR detection should be performed")
 			} else {
-			    assert.False(t, ocrDetectionCalled, "OCR detection should not be performed")
+				assert.False(t, ocrDetectionCalled, "OCR detection should not be performed")
 			}
 		})
 	}

--- a/ocr_test.go
+++ b/ocr_test.go
@@ -404,6 +404,8 @@ func TestProcessDocumentOCR_PartialPageFailure(t *testing.T) {
 	require.NotNil(t, result)
 
 	assert.Equal(t, []int{2}, result.SkippedPages)
+	assert.Equal(t, 3, result.TotalPages)
+	assert.Equal(t, 3, result.PagesAttempted)
 	assert.Contains(t, result.Text, "text from page 1")
 	assert.Contains(t, result.Text, "text from page 3")
 	assert.NotContains(t, result.Text, "text from page 2")


### PR DESCRIPTION
Fixes #932

When a single page fails OCR (e.g. a corrupted image or unsupported format), the whole document processing would bail out. This is pretty annoying for multi-page documents where most pages are fine.

Now per-page OCR errors log a warning and skip that page instead of returning an error. The `ProcessedDocument` struct tracks which pages were skipped in a new `SkippedPages` field. If *all* pages fail, it still returns an error since there's nothing useful to return.

On the `background.go` side, when a document has skipped pages, it still updates the content with whatever succeeded, removes the auto-OCR tag (so it doesn't retry forever), and adds a configurable tag (`OCR_PARTIAL_ERROR_TAG`, defaults to `paperless-gpt-ocr-incomplete`) so users can find and review those documents.

Also fixed a subtle bug where `imageDataList` could get out of sync with the hOCR page results on partial failure, since the image data was appended before the OCR call rather than after.

Test plan:
- `go test ./ocr/...` passes
- The main package has a pre-existing build issue (missing `web-app/dist/*` embedded assets) unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCR now continues past per-page failures, records skipped pages in results, and distinguishes partial vs. full OCR; added configurable partial-OCR tag with a default.

* **Bug Fixes**
  * Skipped pages are logged; tag application/removal updated to always remove the auto-OCR tag, handle partial vs complete tags correctly, and clean up stale partial tags.

* **Tests**
  * Added tests for partial-page failures and all-pages-fail scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->