### PR TITLE
fix: resolve select field label-to-ID mapping for custom fields

### DIFF
--- a/app_llm.go
+++ b/app_llm.go
@@ -401,7 +401,15 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 	var xmlBuilder strings.Builder
 	xmlBuilder.WriteString("<custom_fields>\n")
 	for _, field := range selectedCustomFields {
-		xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\"></field>\n", field.Name, field.DataType))
+		if field.DataType == "select" && field.ExtraData != nil && len(field.ExtraData.SelectOptions) > 0 {
+			xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\">\n", field.Name, field.DataType))
+			for _, opt := range field.ExtraData.SelectOptions {
+				xmlBuilder.WriteString(fmt.Sprintf("    <option id=\"%s\">%s</option>\n", opt.ID, opt.Label))
+			}
+			xmlBuilder.WriteString("  </field>\n")
+		} else {
+			xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\"></field>\n", field.Name, field.DataType))
+		}
 	}
 	xmlBuilder.WriteString("</custom_fields>")
 	customFieldsXML := xmlBuilder.String()

--- a/app_llm.go
+++ b/app_llm.go
@@ -373,7 +373,22 @@ func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, log
 	result := stripReasoning(completion.Choices[0].Content)
 	return strings.TrimSpace(strings.Trim(result, "\"")), nil
 }
+var xmlAttrEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	`"`, "&quot;",
+	"'", "&apos;",
+	"<", "&lt;",
+	">", "&gt;",
+)
 
+var xmlTextEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
+func escapeXMLAttr(s string) string { return xmlAttrEscaper.Replace(s) }
+func escapeXMLText(s string) string { return xmlTextEscaper.Replace(s) }
 // getSuggestedCustomFields generates suggested custom fields for a document using the LLM
 func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, selectedFieldIDs []int, logger *logrus.Entry) ([]CustomFieldSuggestion, error) {
 	// Fetch all available custom fields
@@ -402,13 +417,13 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 	xmlBuilder.WriteString("<custom_fields>\n")
 	for _, field := range selectedCustomFields {
 		if field.DataType == "select" && field.ExtraData != nil && len(field.ExtraData.SelectOptions) > 0 {
-			xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\">\n", field.Name, field.DataType))
+			xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\">\n", escapeXMLAttr(field.Name), escapeXMLAttr(field.DataType)))
 			for _, opt := range field.ExtraData.SelectOptions {
-				xmlBuilder.WriteString(fmt.Sprintf("    <option id=\"%s\">%s</option>\n", opt.ID, opt.Label))
+				xmlBuilder.WriteString(fmt.Sprintf("    <option id=\"%s\">%s</option>\n", escapeXMLAttr(opt.ID), escapeXMLText(opt.Label)))
 			}
 			xmlBuilder.WriteString("  </field>\n")
 		} else {
-			xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\"></field>\n", field.Name, field.DataType))
+			xmlBuilder.WriteString(fmt.Sprintf("  <field name=\"%s\" type=\"%s\"></field>\n", escapeXMLAttr(field.Name), escapeXMLAttr(field.DataType)))
 		}
 	}
 	xmlBuilder.WriteString("</custom_fields>")

--- a/paperless.go
+++ b/paperless.go
@@ -39,10 +39,20 @@ type PaperlessClient struct {
 }
 
 // CustomField represents a custom field from the Paperless-ngx API
+type SelectOption struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+type CustomFieldExtraData struct {
+	SelectOptions []SelectOption `json:"select_options"`
+}
+
 type CustomField struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	DataType string `json:"data_type"`
+	ID        int                   `json:"id"`
+	Name      string                `json:"name"`
+	DataType  string                `json:"data_type"`
+	ExtraData *CustomFieldExtraData `json:"extra_data"`
 }
 
 // DocumentType represents a document type from the Paperless-ngx API


### PR DESCRIPTION
## Problem

When using custom fields of type `select`, paperless-gpt fails to update documents with a 400 error from the Paperless-ngx API:
```json
error updating document: 400, {"custom_fields":[{"non_field_errors":["Value must be an id of an element in [...]"]}]}
```

**Root cause:** Two issues combined:

1. The `CustomField` struct did not include `ExtraData`, so the `select_options` from the API response were silently discarded during JSON parsing.

2. The LLM prompt for custom field suggestions only contained `type="select"` without the available options. The LLM therefore returned human-readable labels (e.g. `"Sonstiges"`) instead of the required option IDs (e.g. `"Ien0jKSg1o3E4E0t"`), causing the API to reject the update.

## Fix

- Added `SelectOption` and `CustomFieldExtraData` structs and an `ExtraData` field to `CustomField` so select options are properly deserialized.
- Extended the LLM prompt XML to include `<option id="...">label</option>` entries for `select`-type fields, so the LLM can return the correct option ID directly.

## Tested

Verified on a Paperless-ngx instance with two `select`-type custom fields (8 and 12 options respectively). Documents are now processed and saved successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Improved custom field support: added structured handling for select option data so multi-option fields render correctly.
* **Bug Fixes**
  - Safer XML output: attribute and text values are now escaped to prevent malformed XML when custom field names, types, or option labels contain special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->