### PR TITLE
fix: remove auto OCR tag on failure to prevent infinite retry loop

### DIFF
--- a/background.go
+++ b/background.go
@@ -232,6 +232,22 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 		if err != nil {
 			docLogger.Errorf("OCR processing failed: %v", err)
 			errs = append(errs, fmt.Errorf("document %d OCR error: %w", document.ID, err))
+
+			// Remove the auto OCR tag and add the failed tag to prevent infinite retry loop
+			updateErr := app.Client.UpdateDocuments(ctx, []DocumentSuggestion{
+				{
+					ID:               document.ID,
+					OriginalDocument: document,
+					RemoveTags:       []string{autoOcrTag},
+					AddTags:          []string{ocrFailedTag},
+				},
+			}, app.Database, false)
+			if updateErr != nil {
+				docLogger.Errorf("Failed to update tags after OCR failure: %v", updateErr)
+			} else {
+				docLogger.Infof("Moved document from '%s' to '%s' after OCR failure", autoOcrTag, ocrFailedTag)
+			}
+
 			continue
 		}
 		if processedDoc == nil {

--- a/background_test.go
+++ b/background_test.go
@@ -38,9 +38,13 @@ func (m *mockOCRProvider) ProcessImage(ctx context.Context, imageData []byte, pa
 // mockDocumentProcessor implements the DocumentProcessor interface for testing
 type mockDocumentProcessor struct {
 	mockText string
+	err      error
 }
 
 func (m *mockDocumentProcessor) ProcessDocumentOCR(ctx context.Context, documentID int, options OCROptions, jobID string) (*ProcessedDocument, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	return &ProcessedDocument{
 		ID:   documentID,
 		Text: m.mockText,
@@ -50,10 +54,11 @@ func (m *mockDocumentProcessor) ProcessDocumentOCR(ctx context.Context, document
 // mockClient implements the ClientInterface for testing
 type mockClient struct {
 	*PaperlessClient
-	documents        map[int]Document
-	tags             map[string]int
-	taggedDocuments  map[string][]Document
-	updateDocsCalled bool
+	documents           map[int]Document
+	tags                map[string]int
+	taggedDocuments     map[string][]Document
+	updateDocsCalled    bool
+	lastUpdateSuggestions []DocumentSuggestion
 }
 
 func newMockClient(baseClient *PaperlessClient) *mockClient {
@@ -71,6 +76,7 @@ func (m *mockClient) GetDocumentsByTag(ctx context.Context, tag string, pageSize
 
 func (m *mockClient) UpdateDocuments(ctx context.Context, documents []DocumentSuggestion, db *gorm.DB, isUndo bool) error {
 	m.updateDocsCalled = true
+	m.lastUpdateSuggestions = documents
 	return nil
 }
 
@@ -540,4 +546,61 @@ func TestProcessAutoOcrTagDocuments(t *testing.T) {
 			assert.True(t, client.updateDocsCalled, "UpdateDocuments should have been called")
 		})
 	}
+}
+
+func TestProcessAutoOcrTagDocuments_FailureRemovesTag(t *testing.T) {
+	// Initialize required global variables
+	autoOcrTag = "paperless-gpt-ocr-auto"
+	pdfOCRCompleteTag = "paperless-gpt-ocr-complete"
+	ocrFailedTag = "paperless-gpt-ocr-failed"
+
+	env := setupTest(t)
+	defer env.teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	// Create mock client
+	client := newMockClient(env.client)
+	client.AddTag(autoOcrTag, 2)
+	client.AddTag(ocrFailedTag, 5)
+
+	// Add a document that will fail OCR
+	doc := Document{
+		ID:               42,
+		Title:            "Sensitive Document",
+		Tags:             []string{autoOcrTag},
+		Content:          "Original content",
+		OriginalFileName: "test.pdf",
+	}
+	client.AddDocument(doc, []string{autoOcrTag})
+
+	// Create a document processor that returns an error (simulating content filtering)
+	docProcessor := &mockDocumentProcessor{
+		err: errors.New("anthropic: failed to create message: API returned unexpected status code: 400: Output blocked by content filtering policy"),
+	}
+
+	app := &App{
+		Client:             client,
+		Database:           env.db,
+		ocrProvider:        &mockOCRProvider{text: ""},
+		docProcessor:       docProcessor,
+		ocrProcessMode:     "image",
+		pdfOCRTagging:      false,
+		pdfOCRCompleteTag:  pdfOCRCompleteTag,
+		pdfSkipExistingOCR: false,
+	}
+
+	count, err := app.processAutoOcrTagDocuments(ctx)
+
+	// Should return an error (the OCR failure) but still process the tag update
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Output blocked by content filtering policy")
+	assert.Equal(t, 0, count, "No documents should count as successfully processed")
+
+	// The critical assertion: UpdateDocuments should have been called to move the tag
+	assert.True(t, client.updateDocsCalled, "UpdateDocuments should have been called to update tags on failure")
+	require.Len(t, client.lastUpdateSuggestions, 1)
+	assert.Equal(t, []string{autoOcrTag}, client.lastUpdateSuggestions[0].RemoveTags, "Should remove the auto OCR tag")
+	assert.Equal(t, []string{ocrFailedTag}, client.lastUpdateSuggestions[0].AddTags, "Should add the OCR failed tag")
 }

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	autoTag                       = os.Getenv("AUTO_TAG")
 	manualOcrTag                  = os.Getenv("MANUAL_OCR_TAG") // Not used yet
 	autoOcrTag                    = os.Getenv("AUTO_OCR_TAG")
+	ocrFailedTag                  = os.Getenv("OCR_FAILED_TAG")
 	ocrProcessMode                = os.Getenv("OCR_PROCESS_MODE")
 	llmProvider                   = os.Getenv("LLM_PROVIDER")
 	llmModel                      = os.Getenv("LLM_MODEL")
@@ -583,6 +584,10 @@ func validateOrDefaultEnvVars() {
 
 	if pdfOCRCompleteTag == "" {
 		pdfOCRCompleteTag = "paperless-gpt-ocr-complete"
+	}
+
+	if ocrFailedTag == "" {
+		ocrFailedTag = "paperless-gpt-ocr-failed"
 	}
 
 	if paperlessBaseURL == "" {


### PR DESCRIPTION
## Summary

- When OCR processing fails (e.g., Anthropic content filtering blocks output for sensitive documents), the `AUTO_OCR_TAG` is never removed from the document
- The background task re-queries tagged documents every 10 seconds, picks up the same document, fails again — creating an infinite retry loop
- This fix removes the auto OCR tag on failure and adds a new configurable `OCR_FAILED_TAG` (default: `paperless-gpt-ocr-failed`) so failed documents are easy to find and can be manually re-processed

## Changes

- `background.go`: On OCR failure, call `UpdateDocuments` to swap `AUTO_OCR_TAG` → `OCR_FAILED_TAG` before continuing
- `main.go`: Add `OCR_FAILED_TAG` env var (default: `paperless-gpt-ocr-failed`)
- `background_test.go`: Add test verifying tag swap on OCR failure, extend mock infrastructure to support error injection

## Test plan

- [x] New test `TestProcessAutoOcrTagDocuments_FailureRemovesTag` verifies the tag swap on OCR failure
- [x] Existing tests still pass
- [x] Manual verification: documents that previously looped now get tagged with `paperless-gpt-ocr-failed` and stop being retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OCR failure handling improved: Documents experiencing OCR processing errors are now automatically tagged and removed from active processing.

* **Configuration**
  * New environment variable added to customize the tag applied to documents that fail OCR processing, with sensible defaults provided if not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->