### PR TITLE
Drop owner field from correspondent POST when nil

### DIFF
--- a/types.go
+++ b/types.go
@@ -134,7 +134,13 @@ type Correspondent struct {
 	MatchingAlgorithm int    `json:"matching_algorithm"`
 	Match             string `json:"match"`
 	IsInsensitive     bool   `json:"is_insensitive"`
-	Owner             *int   `json:"owner"`
+	// omitempty so nil owners are dropped from the JSON body; paperless-ngx
+	// then falls back to the request user (request.user) as the owner of
+	// the newly created object. Sending "owner": null overrides that and
+	// produces ownerless correspondents — they still appear in the
+	// correspondents list, but documents assigned to them are shown as
+	// "private" in the UI instead of the correspondent name.
+	Owner             *int   `json:"owner,omitempty"`
 	SetPermissions    struct {
 		View struct {
 			Users  []int `json:"users"`


### PR DESCRIPTION
Ran into this with my own setup: paperless-gpt creates correspondents with `"owner": null` in the POST body, and paperless-ngx stores them literally. The correspondent itself still appears in the correspondents list, but any document tagged with it is displayed as "private" in the UI instead of showing the correspondent's name.

With `omitempty` on the struct tag Go drops the field when it's nil and paperless-ngx falls back to the request user instead.

Tested on paperless-ngx 2.20 with both a superuser and a regular token. Single struct-tag change plus a short comment, no tests touched.

Happy to adjust if you'd like the commit split differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request payloads now omit the correspondent owner field when it is not set, instead of sending it as null. This prevents unintended null overrides and lets the receiving service apply its default behavior when ownership is unspecified, improving request semantics and interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->