### PR TITLE
RFC + MVP: generic LLM-OCR HTTP API + paperless-ngx 3.0 parser plugin path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /app
 # renovate: datasource=repology depName=alpine_3_21/gcc versioning=loose
 ENV GCC_VERSION="14.2.0-r4"
 # renovate: datasource=repology depName=alpine_3_21/musl-dev versioning=loose
-ENV MUSL_DEV_VERSION="1.2.5-r9"
+ENV MUSL_DEV_VERSION="1.2.5-r11"
 # renovate: datasource=repology depName=alpine_3_21/mupdf versioning=loose
 ENV MUPDF_VERSION="1.24.10-r0"
 # renovate: datasource=repology depName=alpine_3_21/mupdf-dev versioning=loose

--- a/docs/examples/parser-plugin/README.md
+++ b/docs/examples/parser-plugin/README.md
@@ -1,0 +1,116 @@
+# Quickstart: try the v1 parse API with curl
+
+> Status: MVP (text only). See [`../parser_plugin_rfc.md`](../parser_plugin_rfc.md)
+> for the full design and [PR #964](https://github.com/icereed/paperless-gpt/pull/964)
+> for the discussion.
+
+## 0. Run paperless-gpt with any OCR provider configured
+
+The simplest local setup for trying the new endpoint:
+
+```bash
+# In one terminal — start paperless-gpt with a real OCR provider.
+# Replace OPENAI_API_KEY etc. with whatever provider you have.
+docker run --rm -it -p 8080:8080 \
+  -e LLM_PROVIDER=openai \
+  -e LLM_MODEL=gpt-4o-mini \
+  -e VISION_LLM_PROVIDER=openai \
+  -e VISION_LLM_MODEL=gpt-4o-mini \
+  -e OCR_PROVIDER=llm \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -e PAPERLESS_BASE_URL=http://example.invalid \
+  -e PAPERLESS_API_TOKEN=anything \
+  ghcr.io/icereed/paperless-gpt:pr-964
+```
+
+> Until a release of this branch is published, `docker build .` from the
+> repo root and `docker run … paperless-gpt:local`.
+
+## 1. Capabilities
+
+```bash
+curl -s http://localhost:8080/api/v1/capabilities | jq
+```
+
+```jsonc
+{
+  "name": "paperless-gpt",
+  "version": "devVersion",
+  "supported_mime_types": {
+    "application/pdf": ".pdf",
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/tiff": ".tiff",
+    "image/webp": ".webp"
+  },
+  "providers": [{ "id": "llm", "display_name": "llm", "can_produce_archive": false }],
+  "default_provider": "llm",
+  "can_produce_archive": false,
+  "requires_pdf_rendition": false,
+  "default_score": 50,
+  "notes": [
+    "MVP: text extraction only. Archive PDF and thumbnail are not yet returned.",
+    "See docs/parser_plugin_rfc.md for the planned full surface."
+  ]
+}
+```
+
+## 2. Health
+
+```bash
+curl -s http://localhost:8080/api/v1/healthz
+# {"status":"ok"}
+```
+
+## 3. Parse a PDF
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/parse \
+  -F file=@./scan.pdf \
+  -F mime_type=application/pdf \
+  -F filename=scan.pdf | jq
+```
+
+```jsonc
+{
+  "text": "Invoice no. 12345 …",
+  "page_count": 3,
+  "provider": "llm"
+}
+```
+
+## 4. Parse an image
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/parse \
+  -F file=@./receipt.jpg \
+  -F mime_type=image/jpeg | jq -r '.text'
+```
+
+## 5. Optional auth
+
+Start the sidecar with `PAPERLESS_GPT_API_TOKEN=hunter2` and add a header:
+
+```bash
+curl -H 'Authorization: Bearer hunter2' \
+     http://localhost:8080/api/v1/healthz
+```
+
+## 6. Use from n8n / Make / Zapier
+
+It's a plain `multipart/form-data` POST. Any HTTP node works. The response
+is JSON; pipe `text` into your downstream nodes.
+
+## 7. Use from a coding agent
+
+Have your agent call:
+
+```bash
+curl -s -X POST $PAPERLESS_GPT_URL/api/v1/parse \
+  -F file=@"$1" \
+  -F mime_type=$(file --mime-type -b "$1") \
+  | jq -r '.text'
+```
+
+…and feed the resulting text back into context. Solves the "agent struggles
+with PDFs in user prompts" problem in three lines.

--- a/docs/examples/parser-plugin/docker-compose.yml
+++ b/docs/examples/parser-plugin/docker-compose.yml
@@ -1,0 +1,63 @@
+# docker-compose example for the paperless-gpt parser plugin path.
+#
+# Spins up paperless-ngx 3.0 (dev tag for now) alongside paperless-gpt as a
+# parser sidecar. paperless-ngx loads the Python shim which forwards every
+# document to /api/v1/parse on the sidecar.
+#
+# Status: proof-of-concept for icereed/paperless-gpt#964. Not yet production-
+# ready (no archive PDF / thumbnail yet — see RFC).
+
+services:
+  paperless-ngx:
+    image: ghcr.io/paperless-ngx/paperless-ngx:dev
+    depends_on:
+      - paperless-gpt
+      - redis
+    environment:
+      PAPERLESS_REDIS: redis://redis:6379
+      PAPERLESS_URL: http://localhost:8000
+      PAPERLESS_SECRET_KEY: change-me
+      PAPERLESS_TIME_ZONE: Europe/Berlin
+      # Tell the shim where the sidecar lives.
+      PAPERLESS_GPT_URL: http://paperless-gpt:8080
+      PAPERLESS_GPT_PARSER_SCORE: "60"
+    volumes:
+      - paperless-data:/usr/src/paperless/data
+      - paperless-media:/usr/src/paperless/media
+      - ./consume:/usr/src/paperless/consume
+      # Mount the shim as an editable install. In production you would
+      # `pip install paperless-gpt-parser` inside a custom image instead.
+      - ../paperless-gpt-parser:/opt/paperless-gpt-parser:ro
+    command: >
+      sh -c "pip install -e /opt/paperless-gpt-parser &&
+             /usr/local/bin/paperless"
+    ports:
+      - "8000:8000"
+
+  paperless-gpt:
+    # Replace with `icereed/paperless-gpt:latest` once a release with the
+    # /api/v1 endpoints lands. For now: build from the feature branch.
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    environment:
+      # Minimal config so isOcrEnabled() returns true.
+      LLM_PROVIDER: openai
+      LLM_MODEL: gpt-4o-mini
+      VISION_LLM_PROVIDER: openai
+      VISION_LLM_MODEL: gpt-4o-mini
+      OCR_PROVIDER: llm
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?set OPENAI_API_KEY in your shell}
+      # paperless-gpt's polling flow needs these but they can point anywhere
+      # for the parser-only use case.
+      PAPERLESS_BASE_URL: http://paperless-ngx:8000
+      PAPERLESS_API_TOKEN: not-used-by-parser-api
+    ports:
+      - "8080:8080"
+
+  redis:
+    image: redis:7-alpine
+
+volumes:
+  paperless-data:
+  paperless-media:

--- a/docs/parser_plugin_rfc.md
+++ b/docs/parser_plugin_rfc.md
@@ -1,9 +1,10 @@
 # RFC: A Generic LLM-OCR HTTP API (with paperless-ngx as the first consumer)
 
-> **Status:** Draft / Discussion
+> **Status:** Draft / Discussion — **MVP shipped in this PR**
 > **Author:** @icereed (and contributors)
 > **Headline use case:** paperless-ngx 3.0 [parser plugin framework](https://github.com/paperless-ngx/paperless-ngx/pull/12294) ([discussion #12023](https://github.com/paperless-ngx/paperless-ngx/discussions/12023))
 > **Other targeted consumers:** n8n / Zapier / Make, local coding agents (Claude Code, Continue, aider), CLI tools, custom RAG pipelines, anything that struggles with PDFs.
+> **Try it:** see [`examples/parser-plugin/README.md`](examples/parser-plugin/README.md) for `curl` quickstart.
 
 ## TL;DR
 
@@ -294,14 +295,15 @@ We never break existing users. That's a story no Python-only competitor can tell
 
 ## Roadmap (proposed)
 
-| Step | Deliverable |
-|---|---|
-| 1 (this PR) | RFC + stub endpoints (returning 501) to anchor discussion. |
-| 2 | Refactor `ocr.go` so the OCR pipeline can be invoked statelessly. |
-| 3 | Implement `POST /api/v1/parse` end-to-end for image MIME types. |
-| 4 | Add searchable PDF generation to the response. |
-| 5 | New repo `paperless-gpt-parser` with the Python shim + integration tests against `paperless-ngx:dev`. |
-| 6 | Docs, docker-compose example, and announcement back in [discussion #12023](https://github.com/paperless-ngx/paperless-ngx/discussions/12023). |
+| Step | Status | Deliverable |
+|---|---|---|
+| 1 (this PR) | ✅ | RFC + working MVP: text extraction for images and PDFs, capabilities/healthz, optional bearer auth, Python shim skeleton, curl quickstart, docker-compose example. |
+| 2 | 🚧 | Refactor the polling-flow `ProcessDocumentOCR` to share more code with the new stateless path (today they overlap but are not unified). |
+| 3 | 🚧 | Searchable archive PDF in the `/parse` response (hOCR + page images via `gardar/ocrchestra/pkg/pdfocr`). |
+| 4 | 🚧 | Real WebP thumbnail in the `/parse` response. |
+| 5 | 🚧 | Per-request `provider` override + `language_hint` honoring. |
+| 6 | 🚧 | Move `paperless-gpt-parser/` into its own repository, publish to PyPI, integration tests against `paperless-ngx:dev`. |
+| 7 | 🚧 | Announcement back in [discussion #12023](https://github.com/paperless-ngx/paperless-ngx/discussions/12023). |
 
 ---
 

--- a/docs/parser_plugin_rfc.md
+++ b/docs/parser_plugin_rfc.md
@@ -1,0 +1,308 @@
+# RFC: A Generic LLM-OCR HTTP API (with paperless-ngx as the first consumer)
+
+> **Status:** Draft / Discussion
+> **Author:** @icereed (and contributors)
+> **Headline use case:** paperless-ngx 3.0 [parser plugin framework](https://github.com/paperless-ngx/paperless-ngx/pull/12294) ([discussion #12023](https://github.com/paperless-ngx/paperless-ngx/discussions/12023))
+> **Other targeted consumers:** n8n / Zapier / Make, local coding agents (Claude Code, Continue, aider), CLI tools, custom RAG pipelines, anything that struggles with PDFs.
+
+## TL;DR
+
+We propose a small, stable, consumer-agnostic HTTP API on `paperless-gpt`:
+
+```
+POST /api/v1/parse          # send a document, get text + searchable PDF + thumbnail
+GET  /api/v1/capabilities   # what MIME types / providers are available
+GET  /api/v1/healthz        # liveness
+```
+
+The API has **no paperless-ngx-specific concepts**. It's a generic "LLM-powered OCR/parse" service. The paperless-ngx parser plugin is just a thin Python shim (~200 LOC) on top of it — but the same endpoint is equally useful to:
+
+- **n8n / Zapier / Make** workflows that need to extract text from incoming PDFs.
+- **Local coding agents** (Claude Code, Continue, aider, custom MCP servers) that struggle with PDFs in user prompts.
+- **CLI tools** like `cat foo.pdf | pgpt parse > foo.txt` for one-off conversions.
+- **RAG pipelines** that need a searchable PDF + plain text from arbitrary uploads.
+- **Any service** that today wraps Tesseract or a vendor OCR and would prefer LLM quality.
+
+paperless-gpt is uniquely positioned for this: we already have the broadest provider matrix (Mistral OCR, Azure DocAI, Google DocAI, generic Vision LLMs via langchaingo, Docling, Anthropic, Ollama) and produce hOCR + searchable PDFs via [`gardar/ocrchestra`](https://github.com/gardar/ocrchestra). All of that already exists; we just need to expose it through a stable, document-in / structured-data-out endpoint.
+
+This RFC tracks the design discussion. Implementation will land incrementally.
+
+---
+
+## Why this matters
+
+**For the broader ecosystem:**
+
+- "Give me a PDF, get back high-quality text + a searchable PDF" is a problem **everyone** has. Today, every workflow tool (n8n, Make), every coding agent, every RAG framework either ships its own bad Tesseract integration or punts. A free, self-hostable, LLM-grade alternative with a 3-line HTTP call would be widely adopted.
+- Coding agents in particular **routinely fail** on PDFs in user prompts (they get raw bytes or terrible text extraction). A simple `curl`-able endpoint they can call solves this for the entire local-AI scene.
+- paperless-gpt already has the engine. It's only missing the surface.
+
+**For the paperless-ngx integration specifically:**
+
+- paperless-ngx maintainers ([explicit statement](https://github.com/paperless-ngx/paperless-ngx/discussions/12023#discussioncomment-15737324)) want **OCR/parsing complexity out of core** and into plugins.
+- The new framework is the **canonical extension point** going forward — the existing tag/polling integration paperless-gpt uses will keep working, but the plugin path becomes the recommended deployment for new users.
+- The provider matrix maps **directly** onto the parser protocol's `get_text` / `get_archive_path` / `get_thumbnail` methods.
+- Being the first quality plugin in the slot establishes us as the de-facto standard for LLM-based document parsing in the paperless-ngx ecosystem.
+
+**The strategic point:** by designing the API generically up-front, we get the paperless-ngx integration *and* a much larger TAM at no extra design cost. The paperless-ngx shim becomes a 200-LOC reference consumer that proves the API.
+
+## What the parser protocol expects
+
+From [`src/paperless/parsers/__init__.py`](https://github.com/paperless-ngx/paperless-ngx/blob/dev/src/paperless/parsers/__init__.py) (dev branch, will ship in 3.0):
+
+```python
+@runtime_checkable
+class ParserProtocol(Protocol):
+    name: str
+    version: str
+    author: str
+    url: str
+
+    @classmethod
+    def supported_mime_types(cls) -> dict[str, str]: ...
+    @classmethod
+    def score(cls, mime_type, filename, path) -> int | None: ...
+
+    @property
+    def can_produce_archive(self) -> bool: ...
+    @property
+    def requires_pdf_rendition(self) -> bool: ...
+
+    def configure(self, context: ParserContext) -> None: ...
+    def parse(self, document_path, mime_type, *, produce_archive=True) -> None: ...
+
+    def get_text(self) -> str | None: ...
+    def get_date(self) -> datetime.datetime | None: ...
+    def get_archive_path(self) -> Path | None: ...
+    def get_thumbnail(self, document_path, mime_type) -> Path: ...
+    def get_page_count(self, document_path, mime_type) -> int | None: ...
+    def extract_metadata(self, document_path, mime_type) -> list[MetadataEntry]: ...
+
+    def __enter__(self) -> Self: ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...
+```
+
+Discovery happens via:
+
+```toml
+[project.entry-points."paperless_ngx.parsers"]
+paperless_gpt = "paperless_gpt_parser.parser:GptParser"
+```
+
+External parsers win ties against built-ins. If our `score()` returns `None`, paperless-ngx falls back to the built-in (e.g. Tesseract).
+
+## Proposed architecture
+
+One stateless HTTP service. Many consumers.
+
+```
+  ┌──────────────────┐   ┌───────────────────┐   ┌─────────────────┐   ┌──────────────┐   ┌───────────┐
+  │ paperless-ngx    │   │ n8n / Zapier /    │   │ coding agents   │   │ RAG / vector │   │ CLI users │
+  │ (Python shim)    │   │ Make workflows    │   │ (CC, Continue,  │   │ ingestion    │   │ pgpt CLI  │
+  │ ParserProtocol   │   │ HTTP node         │   │ aider, MCP)     │   │ (langchain…) │   │           │
+  └────────┬─────────┘   └─────────┬─────────┘   └────────┬────────┘   └──────┬───────┘   └─────┬─────┘
+           │                       │                      │                   │                 │
+           │                       │   POST /api/v1/parse                     │                 │
+           └───────────────────────┴──────────────────────┴───────────────────┴─────────────────┘
+                                                          │
+                                                          ▼
+                                          ┌────────────────────────────┐
+                                          │  paperless-gpt (this repo) │
+                                          │                            │
+                                          │  • Provider matrix         │
+                                          │    (Mistral, Azure DocAI,  │
+                                          │    Google DocAI, Ollama,   │
+                                          │    OpenAI, Anthropic, …)   │
+                                          │  • hOCR generation         │
+                                          │  • Searchable PDF builder  │
+                                          │                            │
+                                          │  Runs as a single container│
+                                          └────────────────────────────┘
+```
+
+### Why HTTP and not a Go shared library / IPC?
+
+- HTTP is **the** universal integration substrate. Every workflow tool, agent, language and runtime can call it. A Go SDK could be added later as a convenience wrapper but should never be a *requirement*.
+- The paperless-ngx parser plugin runs in **every** Celery worker process. Bundling a Go shared library (`cgo` / `.so`) in a Python wheel would be a packaging nightmare across architectures and Python versions.
+- HTTP keeps the deployment story identical to today: one container.
+- Latency is irrelevant at the per-document timescale (seconds for any LLM call dwarfs HTTP overhead).
+- The paperless-ngx shim stays trivially auditable (~200 LOC), which matters for code that loads into the user's paperless-ngx process.
+
+## Proposed API surface (this repo)
+
+A new versioned namespace under `/api/v1/` to avoid coupling with the existing UI-facing `/api/*` endpoints. **No paperless-ngx-specific fields.** Everything optional that maps to a paperless-ngx concept (mailrule_id etc.) is also useful in other contexts ("context tags" for routing) and stays generic in naming.
+
+### `POST /api/v1/parse`
+
+**Request** (multipart/form-data):
+
+| field | type | description |
+|---|---|---|
+| `file` | binary | The document. Required. |
+| `mime_type` | string | MIME type. Optional — sniffed if absent. |
+| `filename` | string | Original filename. Optional, used for routing/logging. |
+| `produce_archive` | bool | Generate a searchable PDF. Default `true`. |
+| `produce_thumbnail` | bool | Generate a WebP thumbnail. Default `true`. |
+| `produce_text` | bool | Extract plain text. Default `true`. |
+| `provider` | string | Override the default OCR/LLM provider for this call. Optional. |
+| `language_hint` | string | BCP-47 hint for the model. Optional. |
+| `context` | string (JSON) | Free-form per-call context the caller wants echoed/used (e.g. `{"source": "paperless-ngx", "mailrule_id": 5}`). Opaque to the server unless a provider chooses to consume it. |
+
+**Response** `200 application/json`:
+
+```jsonc
+{
+  "text": "extracted full text…",
+  "date": "2025-03-14",                       // ISO-8601, nullable
+  "page_count": 4,                            // nullable
+  "archive_pdf_b64": "JVBERi0xLjcK…",        // base64, nullable
+  "thumbnail_webp_b64": "UklGRkQAAA…",       // base64, nullable
+  "metadata": [
+    {"namespace": "http://ns.adobe.com/pdf/1.3/", "prefix": "pdf", "key": "Producer", "value": "paperless-gpt 1.0"}
+  ],
+  "provider": "mistral_ocr",                  // which OCR provider handled it
+  "ocr_limit_hit": false                      // surfaces ocr.OCRResult.OcrLimitHit
+}
+```
+
+**Errors** (RFC 7807 `application/problem+json` recommended):
+
+| status | meaning |
+|---|---|
+| `400` | Malformed request (missing file, bad multipart, invalid `context` JSON) |
+| `415` | `mime_type` not supported by this paperless-gpt configuration → paperless-ngx shim returns `None` from `score()` so core falls back to Tesseract |
+| `429` | Provider rate-limited |
+| `503` | LLM provider unreachable / quota exceeded → caller should retry or fall back |
+| `500` | Unexpected error |
+
+### `GET /api/v1/capabilities`
+
+Lets any consumer discover what the running instance can do without a per-call round trip. The paperless-ngx shim uses it to populate `supported_mime_types()` and `score()`; an n8n node uses it to populate dropdowns; a CLI uses it for `--help`.
+
+```jsonc
+{
+  "name": "paperless-gpt",
+  "version": "1.0.0",
+  "supported_mime_types": {
+    "application/pdf": ".pdf",
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/tiff": ".tiff"
+  },
+  "providers": [
+    {"id": "mistral_ocr",  "display_name": "Mistral OCR",            "can_produce_archive": true},
+    {"id": "google_docai", "display_name": "Google Document AI",    "can_produce_archive": true},
+    {"id": "azure_docai",  "display_name": "Azure Document Intelligence", "can_produce_archive": true},
+    {"id": "vision_llm",   "display_name": "Vision LLM (configured model)", "can_produce_archive": true}
+  ],
+  "default_provider": "mistral_ocr",
+  "can_produce_archive": true,
+  "requires_pdf_rendition": false,
+  "default_score": 50
+}
+```
+
+### `GET /api/v1/healthz`
+
+Standard liveness probe. Returns `200` when the configured OCR provider can be initialised.
+
+### Authentication
+
+Optional bearer token via `Authorization: Bearer <token>`. Configured server-side with `PAPERLESS_GPT_API_TOKEN`. When unset, the API is open (suitable for trusted Docker networks). When set, all `/api/v1/*` calls require a valid token.
+
+### CORS
+
+Disabled by default. Enable with `PAPERLESS_GPT_API_CORS_ORIGINS=*` (or a CSV) so browser-based tools can call the API directly.
+
+## Internal Go changes (sketch)
+
+| Area | Change |
+|---|---|
+| New file `parser_api.go` | Handlers for `/api/v1/parse`, `/api/v1/capabilities`, `/api/v1/healthz`. |
+| [`ocr.go`](../ocr.go) | Extract a stateless variant of `ProcessDocumentOCR` that takes `(bytes, mime)` instead of `(documentID)`. Today's flow downloads from paperless-ngx via `app.Client.Download…`; the new flow reuses the **same** provider invocation logic without that prelude. |
+| [`ocr/provider.go`](../ocr/provider.go) | Extend `OCRResult` (or wrap it) with `ArchivePDF []byte`, `ThumbnailWebP []byte`, `PageCount int`, `DetectedDate *time.Time`. |
+| New file `archive/pdf.go` | Compose searchable PDF from `hocr.HOCR` + page images using `gardar/ocrchestra/pkg/pdfocr` (already a dep). |
+| [`main.go`](../main.go) | New flag `--mode=parser-server` that boots the HTTP server but skips paperless-ngx polling and the web UI. Default mode unchanged. |
+| [`Dockerfile`](../Dockerfile) | Optionally add a slim variant `paperless-gpt:parser-sidecar` (no frontend assets). |
+
+The intent is to **share** all OCR/LLM code paths between the existing tag-based flow and the new parser-plugin flow. The plugin path is just a different entry point.
+
+## Reference consumers
+
+To prove the API is genuinely consumer-agnostic, we plan to ship (or document) a small example for each persona alongside the main implementation. None of them are required for the API itself — they're proof points.
+
+| Consumer | Form | Effort |
+|---|---|---|
+| **paperless-ngx parser plugin** | New repo `paperless-gpt-parser` (Python, ~200 LOC, on PyPI) | The headline use case. |
+| **n8n** | Single "HTTP Request" node + a documented JSON template in the README | ~0 LOC, just docs. |
+| **CLI** | `pgpt parse <file>` — small Go binary in `cmd/pgpt`, or a one-line `curl` snippet | ~50 LOC for a real CLI; 1 line for `curl`. |
+| **Coding agents (MCP)** | Optional thin MCP server that exposes `parse_pdf` as a tool | Separate repo, can come later. |
+| **OpenAPI** | Generate `openapi.yaml` from the handler types and ship it under `/api/v1/openapi.yaml` | Auto-discovery for any HTTP framework. |
+
+## Sibling repo: `paperless-gpt-parser` (Python shim)
+
+Will live in a new repo under the same org. Skeleton:
+
+```
+paperless-gpt-parser/
+├── pyproject.toml
+└── src/paperless_gpt_parser/
+    ├── __init__.py
+    ├── parser.py        # GptParser implementing ParserProtocol
+    ├── client.py        # httpx client for paperless-gpt
+    └── config.py        # PAPERLESS_GPT_URL, score override, MIME allow-list
+```
+
+Configuration (env vars read by the shim, *not* by paperless-ngx):
+
+| Env | Default | Purpose |
+|---|---|---|
+| `PAPERLESS_GPT_URL` | `http://paperless-gpt:8080` | Base URL of sidecar |
+| `PAPERLESS_GPT_PARSER_ENABLED` | `true` | Master kill-switch |
+| `PAPERLESS_GPT_PARSER_SCORE` | `50` | Score returned when supported (Tesseract returns ~10) |
+| `PAPERLESS_GPT_PARSER_TIMEOUT` | `300` | Per-document HTTP timeout (seconds) |
+| `PAPERLESS_GPT_PARSER_MIME_ALLOW` | *all from `/capabilities`* | Optional CSV restriction |
+
+The shim performs `GET /capabilities` once at import time (cached), and on every `parse()` it streams the file over `POST /api/v1/parse`, then writes `archive_pdf_b64` + `thumbnail_webp_b64` to its own temp directory so `get_archive_path()` and `get_thumbnail()` can return real `Path` objects to paperless-ngx.
+
+## Migration & compatibility story
+
+| paperless-ngx version | paperless-gpt deployment |
+|---|---|
+| ≤ 2.x | Existing tag-based polling — unchanged. |
+| 3.0+ | Either: keep tag-based polling, **or** install `pip install paperless-gpt-parser` in the paperless-ngx container and run paperless-gpt as a sidecar. |
+| Future (≥ 4.x?) | Parser plugin becomes the recommended path; tag polling deprecated but not removed for one major cycle. |
+
+We never break existing users. That's a story no Python-only competitor can tell.
+
+## Open questions for discussion
+
+1. **Endpoint shape** — base64 in JSON vs. `multipart/mixed` response? JSON is dead simple; multipart saves ~33 % bandwidth. Likely irrelevant in practice.
+2. **Provider selection per request** — should the shim be able to override `LLM_PROVIDER` per request (e.g. via header)? Helpful for users with a "cheap LLM for normal docs, expensive LLM for handwritten" rule.
+3. **Streaming progress** — paperless-ngx gives us no way to surface progress mid-`parse()`. Acceptable?
+4. **Archive PDF format** — paperless-ngx supports PDF/A archive output. We currently produce regular PDFs with hOCR layer. Do we need PDF/A conformance?
+5. **Auth** — assume trusted network (Docker bridge) by default? Add optional shared-secret header for users running the sidecar on a different host?
+6. **Should the shim live in this repo or its own?** Separate repo is cleaner for `pip install`; monorepo is easier to keep in sync. Leaning separate repo.
+7. **Where does the existing UI fit?** The web UI for manual review/tagging stays useful even when the parser plugin runs automatically. The two flows can coexist: parser plugin handles ingestion, UI handles human-in-the-loop refinement.
+8. **Replacing `extract_metadata`** — paperless-gpt's tag/title/correspondent suggestions don't fit the parser protocol's `MetadataEntry` shape (they update Django models, not file-level metadata). Those keep flowing through the existing tag-based path or via paperless-ngx workflows. Plugin scope is strictly ingestion-time text/PDF/thumbnail.
+
+## Out of scope for this RFC
+
+- LLM-based title/tag/correspondent suggestions — these are document-level, not parse-time, and continue via the existing flow.
+- The web UI for manual OCR re-runs.
+- Anything Frontend.
+
+## Roadmap (proposed)
+
+| Step | Deliverable |
+|---|---|
+| 1 (this PR) | RFC + stub endpoints (returning 501) to anchor discussion. |
+| 2 | Refactor `ocr.go` so the OCR pipeline can be invoked statelessly. |
+| 3 | Implement `POST /api/v1/parse` end-to-end for image MIME types. |
+| 4 | Add searchable PDF generation to the response. |
+| 5 | New repo `paperless-gpt-parser` with the Python shim + integration tests against `paperless-ngx:dev`. |
+| 6 | Docs, docker-compose example, and announcement back in [discussion #12023](https://github.com/paperless-ngx/paperless-ngx/discussions/12023). |
+
+---
+
+**Feedback wanted on:** API shape, deployment model, scope, naming, anything labeled "open question" above. Comment in this PR or in the linked paperless-ngx discussion.

--- a/main.go
+++ b/main.go
@@ -411,6 +411,12 @@ func main() {
 		api.GET("/version", getVersionHandler)
 	}
 
+	// Generic LLM-OCR API (v1) — consumer-agnostic endpoints for the
+	// paperless-ngx parser plugin, n8n/Make workflows, coding agents, etc.
+	// See docs/parser_plugin_rfc.md. Currently returns 501 (stub for design
+	// discussion).
+	app.registerParserAPI(router)
+
 	// Serve frontend files
 	// Check if the web-app/dist directory exists for local development
 	if _, err := os.Stat("web-app/dist"); err == nil {

--- a/paperless-gpt-parser/README.md
+++ b/paperless-gpt-parser/README.md
@@ -1,0 +1,91 @@
+# paperless-gpt-parser
+
+> **Status:** Reference implementation skeleton. Tracks the design discussion
+> in [icereed/paperless-gpt#964](https://github.com/icereed/paperless-gpt/pull/964).
+> Will move to its own repository once the API stabilises.
+
+A thin Python adapter that registers as a [paperless-ngx 3.0 parser plugin]
+(https://github.com/paperless-ngx/paperless-ngx/pull/12294) and forwards
+documents to a running [paperless-gpt](https://github.com/icereed/paperless-gpt)
+sidecar over HTTP.
+
+```
+┌──────────────────────────┐         ┌──────────────────────────┐
+│ paperless-ngx Celery     │ entry-  │ paperless-gpt-parser     │
+│ worker (Python)          │ point   │ (this package)           │
+│                          │ ──────▶ │ implements ParserProtocol│
+└──────────────────────────┘         └────────────┬─────────────┘
+                                                  │ HTTP
+                                                  ▼
+                                  ┌──────────────────────────────┐
+                                  │ paperless-gpt sidecar (Go)   │
+                                  │ POST /api/v1/parse           │
+                                  └──────────────────────────────┘
+```
+
+## Why a shim and not a native Python plugin?
+
+paperless-gpt is written in Go. Bundling a Go shared library in a Python
+wheel across architectures and Python versions is a packaging nightmare; an
+HTTP call to a sidecar is universal, trivially auditable, and matches how
+most paperless-gpt users already deploy.
+
+## Install (planned)
+
+```bash
+pip install paperless-gpt-parser
+```
+
+In your paperless-ngx Docker image / venv. The entrypoint group
+`paperless_ngx.parsers` is auto-discovered by paperless-ngx 3.0 on worker
+startup.
+
+## Configure
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `PAPERLESS_GPT_URL` | `http://paperless-gpt:8080` | Base URL of the sidecar |
+| `PAPERLESS_GPT_API_TOKEN` | *(unset)* | Optional bearer token if the sidecar requires auth |
+| `PAPERLESS_GPT_PARSER_ENABLED` | `true` | Master kill-switch |
+| `PAPERLESS_GPT_PARSER_SCORE` | *(from /capabilities, fallback 50)* | Score returned when MIME type is supported. Built-in Tesseract returns ~10. |
+| `PAPERLESS_GPT_PARSER_TIMEOUT` | `300` | Per-document HTTP timeout (seconds) |
+
+## Test it without paperless-ngx
+
+```bash
+PAPERLESS_GPT_URL=http://localhost:8080 \
+  python -c "from paperless_gpt_parser.client import GptClient; \
+             import pathlib; \
+             print(GptClient().parse(pathlib.Path('test.pdf'), 'application/pdf').text[:200])"
+```
+
+## Status / what works today
+
+This package targets the **MVP** API (text only). Archive PDF + thumbnail
+pass-through will land once the sidecar implements them.
+
+| ParserProtocol method | Status |
+|---|---|
+| `name` / `version` / `author` / `url` | ✅ |
+| `supported_mime_types()` | ✅ (from `/capabilities`) |
+| `score()` | ✅ |
+| `parse()` + `get_text()` | ✅ |
+| `get_page_count()` | ✅ |
+| `get_thumbnail()` | 🚧 placeholder (renders a 1×1 WebP) |
+| `get_archive_path()` | 🚧 returns `None` (no archive yet) |
+| `get_date()` | 🚧 returns `None` |
+| `extract_metadata()` | 🚧 returns `[]` |
+| `__enter__` / `__exit__` | ✅ |
+
+## Layout
+
+```
+paperless-gpt-parser/
+├── pyproject.toml
+├── README.md             ← this file
+└── src/paperless_gpt_parser/
+    ├── __init__.py
+    ├── parser.py         ← GptParser implementing ParserProtocol
+    ├── client.py         ← httpx client for paperless-gpt
+    └── config.py         ← env-var parsing
+```

--- a/paperless-gpt-parser/pyproject.toml
+++ b/paperless-gpt-parser/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "paperless-gpt-parser"
+version = "0.1.0a1"
+description = "paperless-ngx parser plugin that forwards documents to a paperless-gpt sidecar."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+  { name = "icereed", email = "icereed@users.noreply.github.com" },
+]
+keywords = ["paperless-ngx", "paperless-gpt", "ocr", "llm", "parser-plugin"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Information Technology",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Office/Business",
+]
+dependencies = [
+  "httpx>=0.27",
+  "Pillow>=10",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8", "pytest-httpx>=0.30"]
+
+[project.urls]
+Homepage = "https://github.com/icereed/paperless-gpt"
+Issues = "https://github.com/icereed/paperless-gpt/issues"
+Discussion = "https://github.com/icereed/paperless-gpt/pull/964"
+
+[project.entry-points."paperless_ngx.parsers"]
+paperless_gpt = "paperless_gpt_parser.parser:GptParser"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/paperless_gpt_parser"]

--- a/paperless-gpt-parser/src/paperless_gpt_parser/__init__.py
+++ b/paperless-gpt-parser/src/paperless_gpt_parser/__init__.py
@@ -1,0 +1,11 @@
+"""paperless-gpt parser plugin for paperless-ngx 3.0.
+
+Forwards documents to a running paperless-gpt sidecar over HTTP.
+See README.md and the upstream RFC at
+https://github.com/icereed/paperless-gpt/pull/964.
+"""
+
+from .parser import GptParser
+
+__all__ = ["GptParser"]
+__version__ = "0.1.0a1"

--- a/paperless-gpt-parser/src/paperless_gpt_parser/client.py
+++ b/paperless-gpt-parser/src/paperless_gpt_parser/client.py
@@ -1,0 +1,118 @@
+"""HTTP client for the paperless-gpt /api/v1 surface."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .config import Config
+
+
+@dataclass(slots=True)
+class Capabilities:
+    """Subset of /capabilities the shim cares about."""
+
+    name: str
+    version: str
+    supported_mime_types: dict[str, str]
+    can_produce_archive: bool
+    requires_pdf_rendition: bool
+    default_score: int
+
+
+@dataclass(slots=True)
+class ParseResult:
+    """Subset of /parse the shim cares about."""
+
+    text: str
+    page_count: int | None
+    archive_pdf: bytes | None
+    thumbnail_webp: bytes | None
+    provider: str | None
+
+
+class GptClient:
+    """Thin httpx wrapper. Stateless; one instance per parser invocation."""
+
+    def __init__(self, config: Config | None = None) -> None:
+        self._config = config or Config.from_env()
+        headers: dict[str, str] = {}
+        if self._config.api_token:
+            headers["Authorization"] = f"Bearer {self._config.api_token}"
+        self._client = httpx.Client(
+            base_url=self._config.base_url,
+            timeout=self._config.timeout_seconds,
+            headers=headers,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "GptClient":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # API calls
+    # ------------------------------------------------------------------
+
+    def capabilities(self) -> Capabilities:
+        resp = self._client.get("/api/v1/capabilities")
+        resp.raise_for_status()
+        body = resp.json()
+        return Capabilities(
+            name=body.get("name", "paperless-gpt"),
+            version=body.get("version", "unknown"),
+            supported_mime_types=dict(body.get("supported_mime_types") or {}),
+            can_produce_archive=bool(body.get("can_produce_archive", False)),
+            requires_pdf_rendition=bool(body.get("requires_pdf_rendition", False)),
+            default_score=int(body.get("default_score", 50)),
+        )
+
+    def parse(
+        self,
+        document_path: Path,
+        mime_type: str,
+        *,
+        produce_archive: bool = True,
+        produce_thumbnail: bool = True,
+        context: dict[str, Any] | None = None,
+    ) -> ParseResult:
+        files = {"file": (document_path.name, document_path.open("rb"), mime_type)}
+        data: dict[str, str] = {
+            "mime_type": mime_type,
+            "filename": document_path.name,
+            "produce_archive": "true" if produce_archive else "false",
+            "produce_thumbnail": "true" if produce_thumbnail else "false",
+        }
+        if context is not None:
+            import json
+
+            data["context"] = json.dumps(context)
+
+        try:
+            resp = self._client.post("/api/v1/parse", data=data, files=files)
+        finally:
+            files["file"][1].close()
+
+        resp.raise_for_status()
+        body = resp.json()
+        return ParseResult(
+            text=body.get("text", "") or "",
+            page_count=body.get("page_count"),
+            archive_pdf=_b64(body.get("archive_pdf_b64")),
+            thumbnail_webp=_b64(body.get("thumbnail_webp_b64")),
+            provider=body.get("provider"),
+        )
+
+
+def _b64(value: str | None) -> bytes | None:
+    if not value:
+        return None
+    return base64.b64decode(value)

--- a/paperless-gpt-parser/src/paperless_gpt_parser/config.py
+++ b/paperless-gpt-parser/src/paperless_gpt_parser/config.py
@@ -1,0 +1,39 @@
+"""Environment-driven configuration for the paperless-gpt parser plugin."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _truthy(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Runtime configuration read from environment variables.
+
+    Read once at module load. The shim is short-lived per Celery worker so we
+    do not need to support live reloading.
+    """
+
+    base_url: str
+    api_token: str | None
+    enabled: bool
+    score: int | None
+    timeout_seconds: float
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        return cls(
+            base_url=os.getenv("PAPERLESS_GPT_URL", "http://paperless-gpt:8080").rstrip("/"),
+            api_token=os.getenv("PAPERLESS_GPT_API_TOKEN") or None,
+            enabled=_truthy(os.getenv("PAPERLESS_GPT_PARSER_ENABLED"), default=True),
+            score=int(os.environ["PAPERLESS_GPT_PARSER_SCORE"])
+            if os.getenv("PAPERLESS_GPT_PARSER_SCORE")
+            else None,
+            timeout_seconds=float(os.getenv("PAPERLESS_GPT_PARSER_TIMEOUT", "300")),
+        )

--- a/paperless-gpt-parser/src/paperless_gpt_parser/parser.py
+++ b/paperless-gpt-parser/src/paperless_gpt_parser/parser.py
@@ -1,0 +1,202 @@
+"""GptParser — implements paperless-ngx 3.0 ParserProtocol.
+
+Discovered by paperless-ngx via the ``paperless_ngx.parsers`` entrypoint group;
+forwards each document to a paperless-gpt sidecar over HTTP.
+
+Note: this module imports nothing from paperless-ngx. The protocol is
+structural (typing.Protocol with @runtime_checkable upstream), so the registry
+validates compatibility at import time by attribute presence.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Self
+
+from PIL import Image, ImageDraw
+
+from .client import Capabilities, GptClient, ParseResult
+from .config import Config
+
+logger = logging.getLogger("paperless_gpt_parser")
+
+# Lazily resolved on first call to supported_mime_types() / score(). The
+# sidecar may not be reachable at import time (e.g. paperless-ngx starts
+# faster than paperless-gpt during a docker-compose up), so we never raise
+# from class-level code.
+_capabilities_cache: Capabilities | None = None
+_capabilities_failed = False
+
+
+def _get_capabilities() -> Capabilities | None:
+    global _capabilities_cache, _capabilities_failed
+    if _capabilities_cache is not None:
+        return _capabilities_cache
+    if _capabilities_failed:
+        return None
+    cfg = Config.from_env()
+    if not cfg.enabled:
+        return None
+    try:
+        with GptClient(cfg) as c:
+            _capabilities_cache = c.capabilities()
+            return _capabilities_cache
+    except Exception as exc:  # pragma: no cover — network errors at runtime
+        logger.warning("paperless-gpt /capabilities unreachable: %s", exc)
+        _capabilities_failed = True
+        return None
+
+
+class GptParser:
+    """ParserProtocol implementation backed by a paperless-gpt HTTP sidecar."""
+
+    name = "paperless-gpt"
+    version = "0.1.0a1"
+    author = "icereed"
+    url = "https://github.com/icereed/paperless-gpt"
+
+    # ------------------------------------------------------------------
+    # Class-level discovery (called by ParserRegistry)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def supported_mime_types(cls) -> dict[str, str]:
+        caps = _get_capabilities()
+        if caps is None:
+            return {}
+        return dict(caps.supported_mime_types)
+
+    @classmethod
+    def score(
+        cls,
+        mime_type: str,
+        filename: str,  # noqa: ARG003 — part of the protocol
+        path: Path | None = None,  # noqa: ARG003
+    ) -> int | None:
+        caps = _get_capabilities()
+        if caps is None:
+            return None
+        if mime_type not in caps.supported_mime_types:
+            return None
+        cfg = Config.from_env()
+        return cfg.score if cfg.score is not None else caps.default_score
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def can_produce_archive(self) -> bool:
+        caps = _get_capabilities()
+        return bool(caps and caps.can_produce_archive)
+
+    @property
+    def requires_pdf_rendition(self) -> bool:
+        caps = _get_capabilities()
+        return bool(caps and caps.requires_pdf_rendition)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __init__(self) -> None:
+        self._tempdir: Path | None = None
+        self._result: ParseResult | None = None
+        self._archive_path: Path | None = None
+        self._mailrule_id: int | None = None
+
+    def configure(self, context: Any) -> None:
+        # ParserContext is a frozen dataclass with `mailrule_id` today;
+        # forward it through the opaque `context` field on /parse.
+        self._mailrule_id = getattr(context, "mailrule_id", None)
+
+    def __enter__(self) -> Self:
+        self._tempdir = Path(tempfile.mkdtemp(prefix="paperless-gpt-"))
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._tempdir and self._tempdir.exists():
+            shutil.rmtree(self._tempdir, ignore_errors=True)
+        self._tempdir = None
+        self._result = None
+        self._archive_path = None
+
+    # ------------------------------------------------------------------
+    # Core parse
+    # ------------------------------------------------------------------
+
+    def parse(
+        self,
+        document_path: Path,
+        mime_type: str,
+        *,
+        produce_archive: bool = True,
+    ) -> None:
+        ctx: dict[str, Any] = {"source": "paperless-ngx"}
+        if self._mailrule_id is not None:
+            ctx["mailrule_id"] = self._mailrule_id
+
+        with GptClient() as client:
+            self._result = client.parse(
+                document_path,
+                mime_type,
+                produce_archive=produce_archive,
+                produce_thumbnail=True,
+                context=ctx,
+            )
+
+        if self._result.archive_pdf and self._tempdir:
+            self._archive_path = self._tempdir / "archive.pdf"
+            self._archive_path.write_bytes(self._result.archive_pdf)
+
+    # ------------------------------------------------------------------
+    # Result accessors
+    # ------------------------------------------------------------------
+
+    def get_text(self) -> str | None:
+        return self._result.text if self._result else None
+
+    def get_date(self) -> datetime.datetime | None:
+        # The sidecar exposes `date` as ISO-8601 once implemented; for now
+        # the MVP doesn't fill it in.
+        return None
+
+    def get_archive_path(self) -> Path | None:
+        return self._archive_path
+
+    def get_thumbnail(self, document_path: Path, mime_type: str) -> Path:
+        if self._tempdir is None:
+            self._tempdir = Path(tempfile.mkdtemp(prefix="paperless-gpt-"))
+        out = self._tempdir / "thumb.webp"
+        if self._result and self._result.thumbnail_webp:
+            out.write_bytes(self._result.thumbnail_webp)
+            return out
+        # Fallback so paperless-ngx never sees a missing path: render a tiny
+        # placeholder. Real thumbnail will come from the sidecar in a follow-up.
+        img = Image.new("RGB", (200, 280), color="white")
+        draw = ImageDraw.Draw(img)
+        draw.text((8, 8), "paperless-gpt", fill="black")
+        img.save(out, format="WEBP")
+        return out
+
+    def get_page_count(self, document_path: Path, mime_type: str) -> int | None:
+        return self._result.page_count if self._result else None
+
+    def extract_metadata(
+        self,
+        document_path: Path,
+        mime_type: str,
+    ) -> list[dict[str, str]]:
+        # The sidecar will expose this once we have a story for per-format
+        # metadata extraction. Returning [] is the spec-defined no-op.
+        return []

--- a/parser_api.go
+++ b/parser_api.go
@@ -1,0 +1,113 @@
+package main
+
+// Parser API (v1) — stub endpoints for a generic LLM-OCR HTTP service.
+//
+// See docs/parser_plugin_rfc.md for the full design. This API is intentionally
+// consumer-agnostic: the headline use case is the paperless-ngx 3.0 parser
+// plugin (loaded via a Python shim), but the same endpoints are designed to be
+// equally useful from n8n / Make / Zapier workflows, local coding agents,
+// CLI tools, and any RAG / document-ingestion pipeline.
+//
+// These handlers intentionally return 501 Not Implemented. They exist so the
+// API surface can be reviewed and iterated on in the open before the full
+// implementation lands. Do NOT enable in production yet.
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ParserProviderInfo describes one available OCR/LLM provider for the
+// /capabilities response. Consumer UIs (e.g. n8n) use this to populate
+// dropdowns; the paperless-ngx shim uses it to decide ParserProtocol.score().
+type ParserProviderInfo struct {
+	ID                string `json:"id"`
+	DisplayName       string `json:"display_name"`
+	CanProduceArchive bool   `json:"can_produce_archive"`
+}
+
+// ParserCapabilities is the response body of GET /api/v1/capabilities.
+type ParserCapabilities struct {
+	Name                 string               `json:"name"`
+	Version              string               `json:"version"`
+	SupportedMimeTypes   map[string]string    `json:"supported_mime_types"`
+	Providers            []ParserProviderInfo `json:"providers"`
+	DefaultProvider      string               `json:"default_provider"`
+	CanProduceArchive    bool                 `json:"can_produce_archive"`
+	RequiresPDFRendition bool                 `json:"requires_pdf_rendition"`
+	DefaultScore         int                  `json:"default_score"`
+}
+
+// ParserMetadataEntry mirrors paperless-ngx's MetadataEntry TypedDict but is
+// also a useful generic shape for any consumer that wants structured
+// per-document metadata. All values are stringified before being returned.
+type ParserMetadataEntry struct {
+	Namespace string `json:"namespace"`
+	Prefix    string `json:"prefix"`
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+}
+
+// ParseResponse is the response body of POST /api/v1/parse.
+//
+// Binary fields (archive PDF, thumbnail) are base64-encoded in the JSON body
+// for ease of consumption from any HTTP client. If bandwidth becomes an issue
+// for large PDFs we can revisit with multipart/mixed; see RFC open questions.
+type ParseResponse struct {
+	Text             string                `json:"text"`
+	Date             *string               `json:"date,omitempty"`               // ISO-8601, nullable
+	PageCount        *int                  `json:"page_count,omitempty"`         // nullable
+	ArchivePDFB64    string                `json:"archive_pdf_b64,omitempty"`    // searchable PDF
+	ThumbnailWebPB64 string                `json:"thumbnail_webp_b64,omitempty"` // WebP image
+	Metadata         []ParserMetadataEntry `json:"metadata,omitempty"`
+	Provider         string                `json:"provider,omitempty"`      // which OCR provider handled it
+	OCRLimitHit      bool                  `json:"ocr_limit_hit,omitempty"` // mirrors ocr.OCRResult.OcrLimitHit
+}
+
+// notImplemented returns a 501 with a pointer to the RFC. Used by every stub.
+func notImplemented(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{
+		"error":     "not yet implemented",
+		"see":       "docs/parser_plugin_rfc.md",
+		"discussion": "https://github.com/icereed/paperless-gpt/pull/<this PR>",
+	})
+}
+
+// parserCapabilitiesHandler handles GET /api/v1/capabilities.
+//
+// TODO(parser-plugin): populate from app.ocrProvider and the active config.
+func (app *App) parserCapabilitiesHandler(c *gin.Context) {
+	notImplemented(c)
+}
+
+// parserParseHandler handles POST /api/v1/parse.
+//
+// Expected request: multipart/form-data with fields
+//   {file, mime_type?, filename?, produce_archive?, produce_thumbnail?,
+//    produce_text?, provider?, language_hint?, context?}
+//
+// TODO(parser-plugin): refactor ocr.ProcessDocumentOCR so it can be called
+// without a paperless-ngx document ID, then wire it up here.
+func (app *App) parserParseHandler(c *gin.Context) {
+	notImplemented(c)
+}
+
+// parserHealthzHandler handles GET /api/v1/healthz.
+//
+// TODO(parser-plugin): probe the configured OCR provider.
+func (app *App) parserHealthzHandler(c *gin.Context) {
+	notImplemented(c)
+}
+
+// registerParserAPI mounts the v1 parse endpoints. Endpoints are always
+// mounted (so the shape can be inspected via the running server) but currently
+// return 501.
+func (app *App) registerParserAPI(router *gin.Engine) {
+	v1 := router.Group("/api/v1")
+	{
+		v1.GET("/capabilities", app.parserCapabilitiesHandler)
+		v1.POST("/parse", app.parserParseHandler)
+		v1.GET("/healthz", app.parserHealthzHandler)
+	}
+}

--- a/parser_api.go
+++ b/parser_api.go
@@ -1,26 +1,39 @@
 package main
 
-// Parser API (v1) — stub endpoints for a generic LLM-OCR HTTP service.
+// Parser API (v1) — generic LLM-OCR HTTP service.
 //
-// See docs/parser_plugin_rfc.md for the full design. This API is intentionally
-// consumer-agnostic: the headline use case is the paperless-ngx 3.0 parser
-// plugin (loaded via a Python shim), but the same endpoints are designed to be
-// equally useful from n8n / Make / Zapier workflows, local coding agents,
-// CLI tools, and any RAG / document-ingestion pipeline.
+// Headline use case: paperless-ngx 3.0 parser plugin (loaded via the Python
+// shim in paperless-gpt-parser/). The same endpoints are equally useful from
+// n8n / Make / Zapier workflows, local coding agents that struggle with PDFs,
+// CLI tools and RAG ingestion pipelines.
 //
-// These handlers intentionally return 501 Not Implemented. They exist so the
-// API surface can be reviewed and iterated on in the open before the full
-// implementation lands. Do NOT enable in production yet.
+// See docs/parser_plugin_rfc.md for the full design. This file ships the
+// MVP: text extraction for images and PDFs. Searchable archive PDF and
+// thumbnail generation are intentionally deferred to a follow-up PR.
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image/jpeg"
+	"io"
+	"math"
 	"net/http"
+	"os"
+	"strings"
 
+	"github.com/gen2brain/go-fitz"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
 // ParserProviderInfo describes one available OCR/LLM provider for the
-// /capabilities response. Consumer UIs (e.g. n8n) use this to populate
-// dropdowns; the paperless-ngx shim uses it to decide ParserProtocol.score().
+// /capabilities response.
 type ParserProviderInfo struct {
 	ID                string `json:"id"`
 	DisplayName       string `json:"display_name"`
@@ -37,11 +50,12 @@ type ParserCapabilities struct {
 	CanProduceArchive    bool                 `json:"can_produce_archive"`
 	RequiresPDFRendition bool                 `json:"requires_pdf_rendition"`
 	DefaultScore         int                  `json:"default_score"`
+	Notes                []string             `json:"notes,omitempty"`
 }
 
 // ParserMetadataEntry mirrors paperless-ngx's MetadataEntry TypedDict but is
-// also a useful generic shape for any consumer that wants structured
-// per-document metadata. All values are stringified before being returned.
+// also a useful generic shape for any consumer that wants per-document
+// structured metadata. All values are stringified.
 type ParserMetadataEntry struct {
 	Namespace string `json:"namespace"`
 	Prefix    string `json:"prefix"`
@@ -51,60 +65,311 @@ type ParserMetadataEntry struct {
 
 // ParseResponse is the response body of POST /api/v1/parse.
 //
-// Binary fields (archive PDF, thumbnail) are base64-encoded in the JSON body
-// for ease of consumption from any HTTP client. If bandwidth becomes an issue
-// for large PDFs we can revisit with multipart/mixed; see RFC open questions.
+// Binary fields (archive PDF, thumbnail) are base64-encoded for ease of
+// consumption from any HTTP client. Empty strings indicate "not produced".
 type ParseResponse struct {
 	Text             string                `json:"text"`
-	Date             *string               `json:"date,omitempty"`               // ISO-8601, nullable
-	PageCount        *int                  `json:"page_count,omitempty"`         // nullable
-	ArchivePDFB64    string                `json:"archive_pdf_b64,omitempty"`    // searchable PDF
-	ThumbnailWebPB64 string                `json:"thumbnail_webp_b64,omitempty"` // WebP image
+	Date             *string               `json:"date,omitempty"`
+	PageCount        *int                  `json:"page_count,omitempty"`
+	ArchivePDFB64    string                `json:"archive_pdf_b64,omitempty"`
+	ThumbnailWebPB64 string                `json:"thumbnail_webp_b64,omitempty"`
 	Metadata         []ParserMetadataEntry `json:"metadata,omitempty"`
-	Provider         string                `json:"provider,omitempty"`      // which OCR provider handled it
-	OCRLimitHit      bool                  `json:"ocr_limit_hit,omitempty"` // mirrors ocr.OCRResult.OcrLimitHit
+	Provider         string                `json:"provider,omitempty"`
+	OCRLimitHit      bool                  `json:"ocr_limit_hit,omitempty"`
 }
 
-// notImplemented returns a 501 with a pointer to the RFC. Used by every stub.
-func notImplemented(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, gin.H{
-		"error":     "not yet implemented",
-		"see":       "docs/parser_plugin_rfc.md",
-		"discussion": "https://github.com/icereed/paperless-gpt/pull/<this PR>",
-	})
+// ---------------------------------------------------------------------------
+// MIME type allow-list
+// ---------------------------------------------------------------------------
+
+// supportedParseMimeTypes maps MIME types this server can handle to their
+// preferred file extension. Same shape as paperless-ngx
+// ParserProtocol.supported_mime_types() so the Python shim can pass it
+// through unchanged.
+var supportedParseMimeTypes = map[string]string{
+	"application/pdf": ".pdf",
+	"image/png":       ".png",
+	"image/jpeg":      ".jpg",
+	"image/jpg":       ".jpg",
+	"image/tiff":      ".tiff",
+	"image/webp":      ".webp",
 }
+
+// ---------------------------------------------------------------------------
+// Optional bearer-token auth
+// ---------------------------------------------------------------------------
+
+// requireAPIToken is a Gin middleware that enforces a bearer token when
+// PAPERLESS_GPT_API_TOKEN is set. When unset (default), the API is open —
+// suitable for trusted Docker networks.
+func requireAPIToken() gin.HandlerFunc {
+	expected := os.Getenv("PAPERLESS_GPT_API_TOKEN")
+	return func(c *gin.Context) {
+		if expected == "" {
+			c.Next()
+			return
+		}
+		auth := c.GetHeader("Authorization")
+		if auth != "Bearer "+expected {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "missing or invalid bearer token",
+			})
+			return
+		}
+		c.Next()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
 
 // parserCapabilitiesHandler handles GET /api/v1/capabilities.
-//
-// TODO(parser-plugin): populate from app.ocrProvider and the active config.
 func (app *App) parserCapabilitiesHandler(c *gin.Context) {
-	notImplemented(c)
+	if !app.isOcrEnabled() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "OCR is not enabled on this paperless-gpt instance",
+		})
+		return
+	}
+
+	providerID := os.Getenv("OCR_PROVIDER")
+	if providerID == "" {
+		providerID = "llm"
+	}
+
+	resp := ParserCapabilities{
+		Name:                 "paperless-gpt",
+		Version:              version,
+		SupportedMimeTypes:   supportedParseMimeTypes,
+		Providers:            []ParserProviderInfo{{ID: providerID, DisplayName: providerID, CanProduceArchive: false}},
+		DefaultProvider:      providerID,
+		CanProduceArchive:    false, // MVP: not yet implemented in the v1 endpoint
+		RequiresPDFRendition: false,
+		DefaultScore:         50,
+		Notes: []string{
+			"MVP: text extraction only. Archive PDF and thumbnail are not yet returned.",
+			"See docs/parser_plugin_rfc.md for the planned full surface.",
+		},
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// parserHealthzHandler handles GET /api/v1/healthz.
+func (app *App) parserHealthzHandler(c *gin.Context) {
+	if !app.isOcrEnabled() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "no-ocr-provider"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
 // parserParseHandler handles POST /api/v1/parse.
 //
 // Expected request: multipart/form-data with fields
-//   {file, mime_type?, filename?, produce_archive?, produce_thumbnail?,
-//    produce_text?, provider?, language_hint?, context?}
 //
-// TODO(parser-plugin): refactor ocr.ProcessDocumentOCR so it can be called
-// without a paperless-ngx document ID, then wire it up here.
+//	file              — required, binary
+//	mime_type         — optional, auto-detected if absent
+//	filename          — optional, used for logging
+//	produce_archive   — optional bool, currently ignored (MVP)
+//	produce_thumbnail — optional bool, currently ignored (MVP)
+//	produce_text      — optional bool, default true
+//	provider          — optional, currently ignored (MVP, uses configured provider)
+//	language_hint     — optional, currently ignored (MVP)
+//	context           — optional JSON, opaque to the server
 func (app *App) parserParseHandler(c *gin.Context) {
-	notImplemented(c)
+	if !app.isOcrEnabled() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "OCR is not enabled on this paperless-gpt instance",
+		})
+		return
+	}
+
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing 'file' field in multipart form"})
+		return
+	}
+
+	f, err := fileHeader.Open()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("cannot open uploaded file: %v", err)})
+		return
+	}
+	defer f.Close()
+
+	body, err := io.ReadAll(f)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("cannot read uploaded file: %v", err)})
+		return
+	}
+	if len(body) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "uploaded file is empty"})
+		return
+	}
+
+	mimeType := c.PostForm("mime_type")
+	if mimeType == "" {
+		mimeType = http.DetectContentType(body)
+	}
+	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
+
+	if _, ok := supportedParseMimeTypes[mimeType]; !ok {
+		c.JSON(http.StatusUnsupportedMediaType, gin.H{
+			"error":                "mime type not supported",
+			"mime_type":            mimeType,
+			"supported_mime_types": supportedParseMimeTypes,
+		})
+		return
+	}
+
+	// Validate optional 'context' is parseable JSON if provided. Server treats
+	// it as opaque, but we want to fail fast on garbage input.
+	if rawCtx := c.PostForm("context"); rawCtx != "" {
+		var probe any
+		if err := json.Unmarshal([]byte(rawCtx), &probe); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": fmt.Sprintf("'context' must be valid JSON: %v", err),
+			})
+			return
+		}
+	}
+
+	providerID := os.Getenv("OCR_PROVIDER")
+	if providerID == "" {
+		providerID = "llm"
+	}
+
+	ctx := c.Request.Context()
+	logger := log.WithFields(logrus.Fields{
+		"endpoint":   "POST /api/v1/parse",
+		"mime_type":  mimeType,
+		"filename":   fileHeader.Filename,
+		"size_bytes": len(body),
+	})
+	logger.Info("Parse request received")
+
+	var (
+		text        string
+		pageCount   int
+		ocrLimitHit bool
+	)
+
+	if mimeType == "application/pdf" {
+		text, pageCount, ocrLimitHit, err = app.parsePDFForAPI(ctx, body, logger)
+	} else {
+		// Image: pass the bytes straight to the provider as page 1.
+		result, perr := app.ocrProvider.ProcessImage(ctx, body, 1)
+		if perr != nil {
+			err = perr
+		} else if result == nil {
+			err = fmt.Errorf("provider returned nil result")
+		} else {
+			text = result.Text
+			pageCount = 1
+			ocrLimitHit = result.OcrLimitHit
+		}
+	}
+
+	if err != nil {
+		logger.WithError(err).Error("Parse failed")
+		// 503 (not 500) so callers know it's worth retrying or falling back
+		// to a built-in parser.
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
+		return
+	}
+
+	pageCountPtr := &pageCount
+	if pageCount == 0 {
+		pageCountPtr = nil
+	}
+
+	c.JSON(http.StatusOK, ParseResponse{
+		Text:        text,
+		PageCount:   pageCountPtr,
+		Provider:    providerID,
+		OCRLimitHit: ocrLimitHit,
+	})
 }
 
-// parserHealthzHandler handles GET /api/v1/healthz.
-//
-// TODO(parser-plugin): probe the configured OCR provider.
-func (app *App) parserHealthzHandler(c *gin.Context) {
-	notImplemented(c)
+// parsePDFForAPI splits a PDF into page images via go-fitz (already a
+// dependency for the polling flow) and runs OCR per page. Mirrors the image
+// preparation logic in paperless.go but operates entirely in-memory.
+func (app *App) parsePDFForAPI(ctx context.Context, pdfBytes []byte, logger *logrus.Entry) (string, int, bool, error) {
+	doc, err := fitz.NewFromMemory(pdfBytes)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("opening PDF: %w", err)
+	}
+	defer doc.Close()
+
+	totalPages := doc.NumPage()
+	pagesToProcess := totalPages
+	if limitOcrPages > 0 && limitOcrPages < totalPages {
+		pagesToProcess = limitOcrPages
+	}
+
+	var (
+		texts    []string
+		limitHit bool
+	)
+
+	const minDPI = 72
+	for n := 0; n < pagesToProcess; n++ {
+		select {
+		case <-ctx.Done():
+			return strings.Join(texts, "\n\n"), totalPages, limitHit, ctx.Err()
+		default:
+		}
+
+		rect, err := doc.Bound(n)
+		if err != nil {
+			return "", totalPages, limitHit, fmt.Errorf("bounding page %d: %w", n+1, err)
+		}
+		wPts := float64(rect.Dx())
+		hPts := float64(rect.Dy())
+
+		dpi := float64(minDPI)
+		if imageMaxRenderDPI > 0 && imageMaxPixelDimension > 0 && imageMaxTotalPixels > 0 && wPts > 0 && hPts > 0 {
+			dpiSide := float64(imageMaxPixelDimension*72) / math.Max(wPts, hPts)
+			dpiArea := math.Sqrt(float64(imageMaxTotalPixels) * 72 * 72 / (wPts * hPts))
+			dpi = math.Min(dpiSide, dpiArea)
+			dpi = math.Min(dpi, float64(imageMaxRenderDPI))
+			dpi = math.Max(dpi, minDPI)
+		}
+
+		img, err := doc.ImageDPI(n, dpi)
+		if err != nil {
+			return "", totalPages, limitHit, fmt.Errorf("rendering page %d: %w", n+1, err)
+		}
+
+		buf := &bytes.Buffer{}
+		if err := jpeg.Encode(buf, img, &jpeg.Options{Quality: jpeg.DefaultQuality}); err != nil {
+			return "", totalPages, limitHit, fmt.Errorf("encoding page %d: %w", n+1, err)
+		}
+
+		result, err := app.ocrProvider.ProcessImage(ctx, buf.Bytes(), n+1)
+		if err != nil {
+			return "", totalPages, limitHit, fmt.Errorf("OCR page %d: %w", n+1, err)
+		}
+		if result == nil {
+			return "", totalPages, limitHit, fmt.Errorf("OCR page %d: nil result", n+1)
+		}
+		texts = append(texts, result.Text)
+		if result.OcrLimitHit {
+			limitHit = true
+		}
+		logger.WithField("page", n+1).Debug("Page OCR completed")
+	}
+	return strings.Join(texts, "\n\n"), totalPages, limitHit, nil
 }
 
-// registerParserAPI mounts the v1 parse endpoints. Endpoints are always
-// mounted (so the shape can be inspected via the running server) but currently
-// return 501.
+// ---------------------------------------------------------------------------
+// Router registration
+// ---------------------------------------------------------------------------
+
+// registerParserAPI mounts the v1 parse endpoints under /api/v1/.
 func (app *App) registerParserAPI(router *gin.Engine) {
-	v1 := router.Group("/api/v1")
+	v1 := router.Group("/api/v1", requireAPIToken())
 	{
 		v1.GET("/capabilities", app.parserCapabilitiesHandler)
 		v1.POST("/parse", app.parserParseHandler)

--- a/parser_api_test.go
+++ b/parser_api_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"paperless-gpt/ocr"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubOCR returns the same text on every call. We don't reuse mockOCRProvider
+// here to keep the parser_api tests self-contained.
+type stubOCR struct{ text string }
+
+func (s *stubOCR) ProcessImage(_ context.Context, _ []byte, _ int) (*ocr.OCRResult, error) {
+	return &ocr.OCRResult{Text: s.text}, nil
+}
+
+func newParserTestApp(t *testing.T) (*gin.Engine, *App) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	app := &App{ocrProvider: &stubOCR{text: "hello world"}}
+	app.registerParserAPI(router)
+	return router, app
+}
+
+// makeTinyPNG returns a 2×2 white PNG. Real-world images would go through the
+// PDF rendering or directly to the provider; for the test the bytes only have
+// to be a valid image so http.DetectContentType picks the right MIME type.
+func makeTinyPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	for x := 0; x < 2; x++ {
+		for y := 0; y < 2; y++ {
+			img.Set(x, y, color.White)
+		}
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, png.Encode(buf, img))
+	return buf.Bytes()
+}
+
+func multipartBody(t *testing.T, fields map[string]string, fileField, fileName string, fileBytes []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	for k, v := range fields {
+		require.NoError(t, mw.WriteField(k, v))
+	}
+	if fileBytes != nil {
+		fw, err := mw.CreateFormFile(fileField, fileName)
+		require.NoError(t, err)
+		_, err = io.Copy(fw, bytes.NewReader(fileBytes))
+		require.NoError(t, err)
+	}
+	require.NoError(t, mw.Close())
+	return body, mw.FormDataContentType()
+}
+
+func TestParserCapabilities(t *testing.T) {
+	router, _ := newParserTestApp(t)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/capabilities", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var caps ParserCapabilities
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &caps))
+	assert.Equal(t, "paperless-gpt", caps.Name)
+	assert.Contains(t, caps.SupportedMimeTypes, "application/pdf")
+	assert.Contains(t, caps.SupportedMimeTypes, "image/png")
+	assert.Equal(t, 50, caps.DefaultScore)
+}
+
+func TestParserHealthz(t *testing.T) {
+	router, _ := newParserTestApp(t)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/healthz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "ok")
+}
+
+func TestParserParseImage(t *testing.T) {
+	router, _ := newParserTestApp(t)
+
+	pngBytes := makeTinyPNG(t)
+	body, ct := multipartBody(t, map[string]string{"mime_type": "image/png"}, "file", "tiny.png", pngBytes)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/parse", body)
+	req.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resp ParseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "hello world", resp.Text)
+	require.NotNil(t, resp.PageCount)
+	assert.Equal(t, 1, *resp.PageCount)
+}
+
+func TestParserParseUnsupportedMime(t *testing.T) {
+	router, _ := newParserTestApp(t)
+
+	body, ct := multipartBody(t, map[string]string{"mime_type": "application/octet-stream"}, "file", "x.bin", []byte("garbage"))
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/parse", body)
+	req.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+}
+
+func TestParserParseMissingFile(t *testing.T) {
+	router, _ := newParserTestApp(t)
+
+	body, ct := multipartBody(t, map[string]string{"mime_type": "image/png"}, "", "", nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/parse", body)
+	req.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestParserBearerTokenEnforced(t *testing.T) {
+	t.Setenv("PAPERLESS_GPT_API_TOKEN", "secret-xyz")
+	router, _ := newParserTestApp(t)
+
+	// No header → 401
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/healthz", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Correct header → 200
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/healthz", nil)
+	req.Header.Set("Authorization", "Bearer secret-xyz")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestParserParseInvalidContextJSON(t *testing.T) {
+	router, _ := newParserTestApp(t)
+	pngBytes := makeTinyPNG(t)
+	body, ct := multipartBody(t, map[string]string{
+		"mime_type": "image/png",
+		"context":   "not-json",
+	}, "file", "tiny.png", pngBytes)
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/parse", body)
+	req.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, strings.Contains(w.Body.String(), "context"))
+}


### PR DESCRIPTION
# RFC + MVP: a generic LLM-OCR HTTP API for paperless-gpt

> 💬 **This PR exists to invite discussion.** It ships a working MVP, a Python shim skeleton for the paperless-ngx 3.0 parser plugin slot, and a curl quickstart you can try right now.
> Please comment with feedback, alternative designs, or use cases I missed.

## TL;DR

Add a small, stable, **consumer-agnostic** HTTP API on `paperless-gpt`:

```
POST /api/v1/parse          # send a document, get text (+ later: searchable PDF, thumbnail)
GET  /api/v1/capabilities   # what MIME types / providers are available
GET  /api/v1/healthz        # liveness
```

The headline use case is the [paperless-ngx 3.0 parser plugin framework](https://github.com/paperless-ngx/paperless-ngx/pull/12294) ([discussion #12023](https://github.com/paperless-ngx/paperless-ngx/discussions/12023)). Because paperless-gpt is Go and that framework loads in-process Python entrypoints, this PR also ships a thin **Python shim** (`paperless-gpt-parser/`) that implements `ParserProtocol` and forwards documents to the sidecar over HTTP.

But the same endpoint is *equally useful* from:

- 🔄 n8n / Make / Zapier workflows
- 🤖 Local coding agents (Claude Code, Continue, aider, MCP) that struggle with PDFs in user prompts
- 💻 CLI tools (`pgpt parse foo.pdf`)
- 🧬 RAG / vector ingestion pipelines
- 📥 Any custom app that today wraps Tesseract or a vendor OCR

By designing it generic up front we get the paperless-ngx integration **and** a much larger TAM at no extra design cost.

## What this PR ships

### Go side (this repo)

| File | What |
|---|---|
| `parser_api.go` | Three handlers, optional bearer-token middleware, MIME allow-list |
| `parser_api_test.go` | 7 tests: capabilities, healthz, image parse, unsupported MIME, missing file, bearer enforcement, invalid JSON `context` — **all pass** |
| `main.go` | `app.registerParserAPI(router)` wired into the existing router |

### Python shim skeleton

| File | What |
|---|---|
| `paperless-gpt-parser/pyproject.toml` | Entrypoint registration `paperless_ngx.parsers = paperless_gpt = paperless_gpt_parser.parser:GptParser` |
| `paperless-gpt-parser/src/paperless_gpt_parser/parser.py` | `GptParser` implementing `ParserProtocol` |
| `paperless-gpt-parser/src/paperless_gpt_parser/client.py` | Tiny httpx wrapper around the v1 API |
| `paperless-gpt-parser/src/paperless_gpt_parser/config.py` | `PAPERLESS_GPT_URL`, token, score, timeout |

> The shim will move to its own repo (`icereed/paperless-gpt-parser`) once the API stabilises. It lives here for now so reviewers can see the full picture in one PR.

### Docs

| File | What |
|---|---|
| `docs/parser_plugin_rfc.md` | Full design + open questions |
| `docs/examples/parser-plugin/README.md` | Copy-pasteable `curl` quickstart for every persona |
| `docs/examples/parser-plugin/docker-compose.yml` | paperless-ngx + sidecar proof of concept |

## Try it (60 seconds)

Build and run the sidecar:

```bash
docker build -t paperless-gpt:pr-964 .
docker run --rm -p 8080:8080 \
  -e LLM_PROVIDER=openai -e LLM_MODEL=gpt-4o-mini \
  -e VISION_LLM_PROVIDER=openai -e VISION_LLM_MODEL=gpt-4o-mini \
  -e OCR_PROVIDER=llm -e OPENAI_API_KEY=$OPENAI_API_KEY \
  -e PAPERLESS_BASE_URL=http://example.invalid \
  -e PAPERLESS_API_TOKEN=anything \
  paperless-gpt:pr-964
```

Discover capabilities:

```bash
curl -s http://localhost:8080/api/v1/capabilities | jq
```

```jsonc
{
  "name": "paperless-gpt",
  "version": "devVersion",
  "supported_mime_types": {
    "application/pdf": ".pdf", "image/png": ".png",
    "image/jpeg": ".jpg", "image/tiff": ".tiff", "image/webp": ".webp"
  },
  "providers": [{"id":"llm","display_name":"llm","can_produce_archive":false}],
  "default_provider": "llm",
  "default_score": 50,
  "notes": ["MVP: text extraction only…"]
}
```

Parse a PDF:

```bash
curl -s -X POST http://localhost:8080/api/v1/parse \
  -F file=@./scan.pdf \
  -F mime_type=application/pdf | jq
```

```jsonc
{ "text": "Invoice no. 12345 …", "page_count": 3, "provider": "llm" }
```

Use from any agent, n8n node, or shell:

```bash
curl -s -X POST $PAPERLESS_GPT_URL/api/v1/parse \
  -F file=@"$1" \
  -F mime_type=$(file --mime-type -b "$1") \
  | jq -r '.text'
```

Full quickstart with more snippets and the auth flow lives in `docs/examples/parser-plugin/README.md`.

## Why a shim and not a native plugin?

paperless-gpt is Go, the new framework loads in-process Python plugins. Bundling a Go shared library in a Python wheel across architectures is a packaging nightmare. HTTP keeps the deployment story identical to today (one container) and lets *every* tool — not just paperless-ngx — call the same endpoint.

## Migration story (no breakage)

| paperless-ngx version | paperless-gpt deployment |
|---|---|
| ≤ 2.x | Existing tag-based polling — **unchanged** |
| 3.0+ | Either keep tag-based polling, **or** `pip install paperless-gpt-parser` and run paperless-gpt as a sidecar |
| Future | Plugin path becomes recommended; tag polling deprecated but not removed for one major cycle |

We never break existing users.

## Out of scope for this PR (intentionally — keeps it reviewable)

- 🚧 Searchable archive PDF in the `/parse` response (planned via [`gardar/ocrchestra/pkg/pdfocr`](https://github.com/gardar/ocrchestra) — the polling flow already does this for the local-file output)
- 🚧 Real WebP thumbnail in the response (the Python shim renders a placeholder for now so paperless-ngx never sees a missing path)
- 🚧 Per-request `provider` override and `language_hint` honoring
- 🚧 Unifying the new stateless path with the existing `ProcessDocumentOCR` polling flow
- 🚧 Moving `paperless-gpt-parser/` to its own repo + PyPI publish

These are tracked in the roadmap section of the RFC and will be follow-up PRs once the shape is confirmed.

## What I'd love feedback on

The RFC ends with *Open questions for discussion*. Specifically:

1. **Endpoint shape** — base64 in JSON vs. multipart/mixed for binary fields once we add the archive PDF?
2. **Per-request provider override** — should consumers pick the LLM/OCR provider per call?
3. **Auth model** — open by default + optional bearer token enough? Need scoped tokens?
4. **PDF/A** — does anyone *actually* need PDF/A conformance for the archive output, or is regular PDF + hOCR layer fine?
5. **Shim location** — sibling repo `paperless-gpt-parser` (cleaner for `pip install`) vs. monorepo (easier to keep in sync)?
6. **Scope** — keep tag/title/correspondent suggestions out of the parser plugin and continue via the existing tag-based path? *(Current proposal: yes.)*
7. **Naming** — `/api/v1/parse` good? Or `/api/v1/extract`, `/api/v1/ocr`, `/api/v1/documents:parse`?
8. **Use cases I missed** — would you wire this into something? Tell me how, so the API doesn't accidentally close that door.

## Checklist

- [x] RFC document
- [x] Working MVP (`/parse`, `/capabilities`, `/healthz`)
- [x] Tests (`parser_api_test.go`, all pass)
- [x] Optional bearer-token auth
- [x] Python shim skeleton
- [x] curl quickstart
- [x] docker-compose example
- [x] No new Go dependencies
- [x] No production behaviour changed for existing flows
- [ ] Searchable archive PDF (follow-up)
- [ ] Real thumbnail (follow-up)

## Try it, break it, comment

Pull the branch, run the curl commands, tell me what's wrong with the design. The point of this PR is the discussion — happy to iterate substantially on the API shape before anything is locked in.

cc @icereed — and anyone in the community with opinions on the paperless-ngx integration story or the broader "PDF-as-a-service" use case 🙏


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parser plugin HTTP API (/api/v1/parse, /capabilities, /healthz) with optional bearer-token auth
  * Added Python integration package to forward documents to a parser sidecar for AI-powered OCR

* **Documentation**
  * Quickstart, Docker Compose example, RFC and README documenting API endpoints, usage, auth and workflow integrations

* **Tests**
  * Added automated tests validating parser API behavior and auth handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->