### PR TITLE
feat: add iOS OCR Server provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,24 @@ FROM docker.io/golang:1.25.5-alpine3.21 AS builder
 # Set the working directory inside the container
 WORKDIR /app
 
-# Install necessary packages
+# renovate: datasource=repology depName=alpine_3_21/gcc versioning=loose
+ENV GCC_VERSION="14.2.0-r4"
+# renovate: datasource=repology depName=alpine_3_21/musl-dev versioning=loose
+ENV MUSL_DEV_VERSION="1.2.5-r11"
+# renovate: datasource=repology depName=alpine_3_21/mupdf versioning=loose
+ENV MUPDF_VERSION="1.24.10-r1"
+# renovate: datasource=repology depName=alpine_3_21/mupdf-dev versioning=loose
+ENV MUPDF_DEV_VERSION="1.24.10-r1"
+# renovate: datasource=repology depName=alpine_3_21/sed versioning=loose
+ENV SED_VERSION="4.9-r2"
+
+# Install necessary packages with pinned versions
 RUN apk add --no-cache \
-    gcc \
-    musl-dev \
-    mupdf \
-    mupdf-dev \
-    sed
+    "gcc=${GCC_VERSION}" \
+    "musl-dev=${MUSL_DEV_VERSION}" \
+    "mupdf=${MUPDF_VERSION}" \
+    "mupdf-dev=${MUPDF_DEV_VERSION}" \
+    "sed=${SED_VERSION}"
 
 # Copy go.mod and go.sum files
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,24 +30,13 @@ FROM docker.io/golang:1.25.5-alpine3.21 AS builder
 # Set the working directory inside the container
 WORKDIR /app
 
-# renovate: datasource=repology depName=alpine_3_21/gcc versioning=loose
-ENV GCC_VERSION="14.2.0-r4"
-# renovate: datasource=repology depName=alpine_3_21/musl-dev versioning=loose
-ENV MUSL_DEV_VERSION="1.2.5-r11"
-# renovate: datasource=repology depName=alpine_3_21/mupdf versioning=loose
-ENV MUPDF_VERSION="1.24.10-r1"
-# renovate: datasource=repology depName=alpine_3_21/mupdf-dev versioning=loose
-ENV MUPDF_DEV_VERSION="1.24.10-r1"
-# renovate: datasource=repology depName=alpine_3_21/sed versioning=loose
-ENV SED_VERSION="4.9-r2"
-
-# Install necessary packages with pinned versions
+# Install necessary packages
 RUN apk add --no-cache \
-    "gcc=${GCC_VERSION}" \
-    "musl-dev=${MUSL_DEV_VERSION}" \
-    "mupdf=${MUPDF_VERSION}" \
-    "mupdf-dev=${MUPDF_DEV_VERSION}" \
-    "sed=${SED_VERSION}"
+    gcc \
+    musl-dev \
+    mupdf \
+    mupdf-dev \
+    sed
 
 # Copy go.mod and go.sum files
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,14 @@ FROM docker.io/golang:1.25.5-alpine3.21 AS builder
 # Set the working directory inside the container
 WORKDIR /app
 
-# Package versions for Renovate
 # renovate: datasource=repology depName=alpine_3_21/gcc versioning=loose
 ENV GCC_VERSION="14.2.0-r4"
 # renovate: datasource=repology depName=alpine_3_21/musl-dev versioning=loose
-ENV MUSL_DEV_VERSION="1.2.5-r9"
+ENV MUSL_DEV_VERSION="1.2.5-r11"
 # renovate: datasource=repology depName=alpine_3_21/mupdf versioning=loose
-ENV MUPDF_VERSION="1.24.10-r0"
+ENV MUPDF_VERSION="1.24.10-r1"
 # renovate: datasource=repology depName=alpine_3_21/mupdf-dev versioning=loose
-ENV MUPDF_DEV_VERSION="1.24.10-r0"
+ENV MUPDF_DEV_VERSION="1.24.10-r1"
 # renovate: datasource=repology depName=alpine_3_21/sed versioning=loose
 ENV SED_VERSION="4.9-r2"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,15 @@ FROM docker.io/golang:1.25.5-alpine3.21 AS builder
 # Set the working directory inside the container
 WORKDIR /app
 
+# Package versions for Renovate
 # renovate: datasource=repology depName=alpine_3_21/gcc versioning=loose
 ENV GCC_VERSION="14.2.0-r4"
 # renovate: datasource=repology depName=alpine_3_21/musl-dev versioning=loose
-ENV MUSL_DEV_VERSION="1.2.5-r11"
+ENV MUSL_DEV_VERSION="1.2.5-r9"
 # renovate: datasource=repology depName=alpine_3_21/mupdf versioning=loose
-ENV MUPDF_VERSION="1.24.10-r1"
+ENV MUPDF_VERSION="1.24.10-r0"
 # renovate: datasource=repology depName=alpine_3_21/mupdf-dev versioning=loose
-ENV MUPDF_DEV_VERSION="1.24.10-r1"
+ENV MUPDF_DEV_VERSION="1.24.10-r0"
 # renovate: datasource=repology depName=alpine_3_21/sed versioning=loose
 ENV SED_VERSION="4.9-r2"
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ https://github.com/user-attachments/assets/bd5d38b9-9309-40b9-93ca-918dfa4f3fd4
    - **Google Document AI**: Leverage Google's powerful Document AI for OCR tasks.
    - **Azure Document Intelligence**: Use Microsoft's enterprise OCR solution.
    - **Docling Server**: Self-hosted OCR and document conversion service
+   - **iOS OCR Server**: Use Apple's Vision Framework via an iPhone for private, on-device OCR
 
 3. **Automatic Title, Tag & Created Date Generation**  
    No more guesswork. Let the AI do the naming and categorizing. You can easily review suggestions and refine them if needed.
@@ -88,6 +89,7 @@ https://github.com/user-attachments/assets/bd5d38b9-9309-40b9-93ca-918dfa4f3fd4
     - [2. Azure Document Intelligence](#2-azure-document-intelligence)
     - [3. Google Document AI](#3-google-document-ai)
     - [4. Docling Server](#4-docling-server)
+    - [5. iOS OCR Server](#5-ios-ocr-server)
   - [OCR Processing Modes](#ocr-processing-modes)
     - [Image Mode (Default)](#image-mode-default)
     - [PDF Mode](#pdf-mode)
@@ -383,6 +385,24 @@ paperless-gpt supports four different OCR providers, each with unique strengths 
   DOCLING_OCR_ENGINE: "macocr" # Optional, defaults to "easyocr" (only used when `DOCLING_OCR_PIPELINE is set to 'standard')
   ```
 
+### 5. iOS OCR Server
+
+- **Key Features**:
+  - Uses Apple's Vision Framework via an iPhone for on-device OCR
+  - 100% local processing, no cloud dependencies, full privacy
+  - Supports multiple languages with automatic detection
+  - No API keys or external accounts needed
+- **Best For**:
+  - Users with an iOS device on the same network
+  - Privacy-sensitive environments
+  - Quick setup without cloud OCR services
+- **Configuration**:
+  ```yaml
+  OCR_PROVIDER: "ios_ocr"
+  IOS_OCR_SERVER_URL: "http://192.168.1.100:8000"
+  IOS_OCR_SERVER_TIMEOUT: "60" # optional, default 60s
+  ```
+
 ## OCR Processing Modes
 
 paperless-gpt offers different methods for processing documents, giving you flexibility based on your needs and OCR provider capabilities:
@@ -417,6 +437,7 @@ Different OCR providers support different processing modes:
 | **Google Document AI** | ✅ | ✅ | ✅ |
 | **Mistral OCR** | ✅ | ✅ | ✅ |
 | **Docling Server** | ✅ | ✅ | ✅ |
+| **iOS OCR Server** | ✅ | ❌ | ❌ |
 
 > **Important**: paperless-gpt will validate your configuration at startup and prevent unsupported mode/provider combinations. If you specify an unsupported mode for your provider, the application will fail to start with a clear error message.
 
@@ -558,7 +579,7 @@ For best results with the enhanced OCR features:
 | `LLM_REQUESTS_PER_MINUTE`           | Maximum requests per minute for the main LLM. Useful for managing API costs or local LLM load.                                                                                                | No       | 120                        |
 | `LLM_MAX_RETRIES`                   | Maximum retry attempts for failed main LLM requests.                                                                                                                                          | No       | 3                          |
 | `LLM_BACKOFF_MAX_WAIT`              | Maximum wait time between retries for the main LLM (e.g., `30s`).                                                                                                                             | No       | 30s                        |
-| `OCR_PROVIDER`                      | OCR provider to use (`llm`, `azure`, or `google_docai`).                                                                                                                                      | No       | llm                        |
+| `OCR_PROVIDER`                      | OCR provider to use (`llm`, `azure`, `google_docai`, `docling`, `mistral_ocr`, `ios_ocr`).                                                                                                    | No       | llm                        |
 | `OCR_PROCESS_MODE`                  | Method for processing documents: `image` (convert to images first), `pdf` (process PDF pages directly), or `whole_pdf` (entire PDF at once).                                                  | No       | image                      |
 | `VISION_LLM_PROVIDER`               | AI backend for LLM OCR (`openai`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`.                                                                                    | Cond.    |                            |
 | `VISION_LLM_MODEL`                  | Model name for LLM OCR (e.g. `minicpm-v`). Required if OCR_PROVIDER is `llm`.                                                                                                                 | Cond.    |                            |
@@ -582,6 +603,8 @@ For best results with the enhanced OCR features:
 | `DOCLING_IMAGE_EXPORT_MODE`         | Mode for image export. Optional; defaults to `embedded` if unset.                                                                                                                             | No       | embedded                   |
 | `DOCLING_OCR_PIPELINE`              | Sets the pipeline type. Optional; defaults to `vlm` if unset.                                                                                                                                 | No       | vlm                        |
 | `DOCLING_OCR_ENGINE`                | Sets the ocr engine, if `DOCLING_OCR_PIPELINE` is set to `standard`. Optional; defaults to `easyocr`                                                                                          | No       | easyocr                    |
+| `IOS_OCR_SERVER_URL`                | URL of the iOS OCR Server (e.g. `http://192.168.1.100:8000`). Required if OCR_PROVIDER is `ios_ocr`.                                                                                          | Cond.    |                            |
+| `IOS_OCR_SERVER_TIMEOUT`            | HTTP request timeout in seconds for the iOS OCR Server.                                                                                                                                       | No       | 60                         |
 | `CREATE_LOCAL_HOCR`                 | Whether to save hOCR files locally.                                                                                                                                                           | No       | false                      |
 | `LOCAL_HOCR_PATH`                   | Path where hOCR files will be saved when hOCR generation is enabled.                                                                                                                          | No       | /app/hocr                  |
 | `CREATE_LOCAL_PDF`                  | Whether to save enhanced PDFs locally.                                                                                                                                                        | No       | false                      |

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ paperless-gpt supports four different OCR providers, each with unique strengths 
 
 ### 5. iOS OCR Server
 
+Uses the [OCR Server](https://apps.apple.com/ch/app/ocr-server/id6749533041) iOS app to perform OCR using Apple's Vision Framework.
+
 - **Key Features**:
   - Uses Apple's Vision Framework via an iPhone for on-device OCR
   - 100% local processing, no cloud dependencies, full privacy

--- a/main.go
+++ b/main.go
@@ -83,6 +83,8 @@ var (
 	doclingImageExportMode        = os.Getenv("DOCLING_IMAGE_EXPORT_MODE")
 	doclingOCRPipeline            = os.Getenv("DOCLING_OCR_PIPELINE")
 	doclingOCREngine              = os.Getenv("DOCLING_OCR_ENGINE")
+	iosOcrServerURL               = os.Getenv("IOS_OCR_SERVER_URL")
+	iosOcrServerTimeout           = os.Getenv("IOS_OCR_SERVER_TIMEOUT")
 	googleThinkingBudget          *int32 // Will be parsed from GOOGLEAI_THINKING_BUDGET
 
 	// Templates
@@ -281,6 +283,7 @@ func main() {
 		DoclingImageExportMode:   doclingImageExportMode,
 		DoclingOCRPipeline:       doclingOCRPipeline,
 		DoclingOCREngine:         doclingOCREngine,
+		IosOcrServerURL:         iosOcrServerURL,
 		EnableHOCR:               true, // Always generate hOCR struct if provider supports it
 		VisionLLMMaxTokens:       visionLlmMaxTokens,
 		VisionLLMTemperature:     visionLlmTemperature,
@@ -296,6 +299,15 @@ func main() {
 			ocrConfig.AzureTimeout = timeout
 		} else {
 			log.Warnf("Invalid AZURE_DOCAI_TIMEOUT_SECONDS value: %v, using default", err)
+		}
+	}
+
+	// Parse iOS OCR Server timeout if set
+	if iosOcrServerTimeout != "" {
+		if timeout, err := strconv.Atoi(iosOcrServerTimeout); err == nil {
+			ocrConfig.IosOcrServerTimeout = timeout
+		} else {
+			log.Warnf("Invalid IOS_OCR_SERVER_TIMEOUT value: %v, using default (60)", err)
 		}
 	}
 
@@ -537,6 +549,7 @@ func validateOCRProviderModeCompatibility(provider, mode, visionProvider string)
 		"google_docai": {"image", "pdf", "whole_pdf"}, // Google Document AI supports all modes
 		"mistral_ocr":  {"image", "pdf", "whole_pdf"}, // Mistral OCR supports all modes
 		"docling":      {"image", "pdf", "whole_pdf"}, // Docling supports image and PDF modes
+		"ios_ocr":      {"image"},                     // iOS OCR Server supports image mode only
 	}
 
 	// Google Gemini API natively handles PDF documents
@@ -636,6 +649,12 @@ func validateOrDefaultEnvVars() {
 		if doclingOCRPipeline == "standard" && doclingOCREngine == "" {
 			doclingOCREngine = "easyocr"
 			log.Infof("DOCLING_OCR_ENGINE not set, defaulting to %s", doclingOCREngine)
+		}
+	}
+
+	if ocrProvider == "ios_ocr" {
+		if iosOcrServerURL == "" {
+			log.Fatal("Please set the IOS_OCR_SERVER_URL environment variable for iOS OCR Server provider")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -305,7 +305,11 @@ func main() {
 	// Parse iOS OCR Server timeout if set
 	if iosOcrServerTimeout != "" {
 		if timeout, err := strconv.Atoi(iosOcrServerTimeout); err == nil {
-			ocrConfig.IosOcrServerTimeout = timeout
+			if timeout > 0 {
+				ocrConfig.IosOcrServerTimeout = timeout
+			} else {
+				log.Warnf("Invalid IOS_OCR_SERVER_TIMEOUT value: %d, must be positive, using default (60)", timeout)
+			}
 		} else {
 			log.Warnf("Invalid IOS_OCR_SERVER_TIMEOUT value: %v, using default (60)", err)
 		}

--- a/ocr/iosocr_provider.go
+++ b/ocr/iosocr_provider.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	defaultIosOcrTimeout = 60
+	maxResponseSize      = 1 * 1024 * 1024 // 1MB
 )
 
 // IosOcrProvider implements OCR using the iOS OCR Server app
@@ -120,24 +121,28 @@ func (p *IosOcrProvider) ProcessImage(ctx context.Context, imageContent []byte, 
 	}
 	defer resp.Body.Close()
 
-	respBodyBytes, err := io.ReadAll(resp.Body)
+	respBodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		logger.WithError(err).Error("Failed to read response body")
 		return nil, fmt.Errorf("error reading iOS OCR response body: %w", err)
 	}
+	respSize := len(respBodyBytes)
 
 	if resp.StatusCode != http.StatusOK {
 		logger.WithFields(logrus.Fields{
-			"status_code": resp.StatusCode,
-			"response":    string(respBodyBytes),
+			"status_code":   resp.StatusCode,
+			"response_size": respSize,
 		}).Error("Received non-OK status from iOS OCR Server")
-		return nil, fmt.Errorf("iOS OCR Server returned status %d: %s", resp.StatusCode, string(respBodyBytes))
+		return nil, fmt.Errorf("iOS OCR Server returned status %d (response size: %d bytes)", resp.StatusCode, respSize)
 	}
 
 	var ocrResp IosOcrUploadResponse
 	if err := json.Unmarshal(respBodyBytes, &ocrResp); err != nil {
-		logger.WithError(err).WithField("response", string(respBodyBytes)).Error("Failed to parse iOS OCR JSON response")
-		return nil, fmt.Errorf("error parsing iOS OCR JSON response: %w", err)
+		logger.WithError(err).WithFields(logrus.Fields{
+			"status_code":   resp.StatusCode,
+			"response_size": respSize,
+		}).Error("Failed to parse iOS OCR JSON response")
+		return nil, fmt.Errorf("error parsing iOS OCR JSON response (status: %d, size: %d bytes): %w", resp.StatusCode, respSize, err)
 	}
 
 	if !ocrResp.Success {

--- a/ocr/iosocr_provider.go
+++ b/ocr/iosocr_provider.go
@@ -1,0 +1,167 @@
+package ocr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultIosOcrTimeout = 60
+)
+
+// IosOcrProvider implements OCR using the iOS OCR Server app
+type IosOcrProvider struct {
+	serverURL  string
+	httpClient *retryablehttp.Client
+}
+
+// IosOcrUploadResponse mirrors the JSON response from the iOS OCR Server
+type IosOcrUploadResponse struct {
+	Success     bool        `json:"success"`
+	Message     string      `json:"message"`
+	OcrResult   string      `json:"ocr_result"`
+	ImageWidth  int         `json:"image_width"`
+	ImageHeight int         `json:"image_height"`
+	OcrBoxes    interface{} `json:"ocr_boxes"`
+}
+
+func newIosOcrProvider(config Config) (*IosOcrProvider, error) {
+	logger := log.WithFields(logrus.Fields{
+		"server_url": config.IosOcrServerURL,
+	})
+	logger.Info("Creating new iOS OCR Server provider")
+
+	if config.IosOcrServerURL == "" {
+		return nil, fmt.Errorf("missing required iOS OCR Server URL")
+	}
+
+	timeout := defaultIosOcrTimeout
+	if config.IosOcrServerTimeout > 0 {
+		timeout = config.IosOcrServerTimeout
+	}
+
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	client.RetryWaitMin = 1 * time.Second
+	client.RetryWaitMax = 10 * time.Second
+	client.HTTPClient.Timeout = time.Duration(timeout) * time.Second
+	client.Logger = logger
+
+	// Normalize server URL: strip trailing slash for consistent URL building
+	serverURL := strings.TrimRight(config.IosOcrServerURL, "/")
+
+	provider := &IosOcrProvider{
+		serverURL:  serverURL,
+		httpClient: client,
+	}
+
+	logger.Info("Successfully initialized iOS OCR Server provider")
+	return provider, nil
+}
+
+func (p *IosOcrProvider) ProcessImage(ctx context.Context, imageContent []byte, pageNumber int) (*OCRResult, error) {
+	logger := log.WithFields(logrus.Fields{
+		"provider": "ios_ocr",
+		"url":      p.serverURL,
+		"page":     pageNumber,
+	})
+	logger.Debug("Starting iOS OCR Server processing")
+
+	uploadURL := p.serverURL + "/upload"
+
+	// Build multipart form request
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	part, err := writer.CreateFormFile("file", "document.png")
+	if err != nil {
+		logger.WithError(err).Error("Failed to create form file")
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	_, err = io.Copy(part, bytes.NewReader(imageContent))
+	if err != nil {
+		logger.WithError(err).Error("Failed to copy image content to form")
+		return nil, fmt.Errorf("failed to copy image content to form: %w", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		logger.WithError(err).Error("Failed to close multipart writer")
+		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := retryablehttp.NewRequestWithContext(ctx, "POST", uploadURL, &requestBody)
+	if err != nil {
+		logger.WithError(err).Error("Failed to create HTTP request")
+		return nil, fmt.Errorf("error creating iOS OCR request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	logger.WithField("url", uploadURL).Debug("Sending request to iOS OCR Server")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		logger.WithError(err).Error("Failed to send request to iOS OCR Server")
+		return nil, fmt.Errorf("error sending request to iOS OCR Server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.WithError(err).Error("Failed to read response body")
+		return nil, fmt.Errorf("error reading iOS OCR response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logger.WithFields(logrus.Fields{
+			"status_code": resp.StatusCode,
+			"response":    string(respBodyBytes),
+		}).Error("Received non-OK status from iOS OCR Server")
+		return nil, fmt.Errorf("iOS OCR Server returned status %d: %s", resp.StatusCode, string(respBodyBytes))
+	}
+
+	var ocrResp IosOcrUploadResponse
+	if err := json.Unmarshal(respBodyBytes, &ocrResp); err != nil {
+		logger.WithError(err).WithField("response", string(respBodyBytes)).Error("Failed to parse iOS OCR JSON response")
+		return nil, fmt.Errorf("error parsing iOS OCR JSON response: %w", err)
+	}
+
+	if !ocrResp.Success {
+		logger.WithFields(logrus.Fields{
+			"message": ocrResp.Message,
+		}).Error("iOS OCR Server returned failure")
+		return nil, fmt.Errorf("iOS OCR Server processing failed: %s", ocrResp.Message)
+	}
+
+	result := &OCRResult{
+		Text: ocrResp.OcrResult,
+		Metadata: map[string]string{
+			"provider":     "ios_ocr",
+			"has_content":  fmt.Sprintf("%t", ocrResp.OcrResult != ""),
+			"image_width":  fmt.Sprintf("%d", ocrResp.ImageWidth),
+			"image_height": fmt.Sprintf("%d", ocrResp.ImageHeight),
+		},
+	}
+
+	logger.WithFields(logrus.Fields{
+		"content_length": len(result.Text),
+		"image_width":    ocrResp.ImageWidth,
+		"image_height":   ocrResp.ImageHeight,
+	}).Info("Successfully processed image with iOS OCR Server")
+
+	return result, nil
+}

--- a/ocr/iosocr_provider.go
+++ b/ocr/iosocr_provider.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,7 +22,7 @@ const (
 // IosOcrProvider implements OCR using the iOS OCR Server app
 type IosOcrProvider struct {
 	serverURL  string
-	httpClient *retryablehttp.Client
+	httpClient *http.Client
 }
 
 // IosOcrUploadResponse mirrors the JSON response from the iOS OCR Server
@@ -36,6 +35,7 @@ type IosOcrUploadResponse struct {
 	OcrBoxes    interface{} `json:"ocr_boxes"`
 }
 
+// newIosOcrProvider creates a new IosOcrProvider with the given configuration.
 func newIosOcrProvider(config Config) (*IosOcrProvider, error) {
 	logger := log.WithFields(logrus.Fields{
 		"server_url": config.IosOcrServerURL,
@@ -51,12 +51,9 @@ func newIosOcrProvider(config Config) (*IosOcrProvider, error) {
 		timeout = config.IosOcrServerTimeout
 	}
 
-	client := retryablehttp.NewClient()
-	client.RetryMax = 3
-	client.RetryWaitMin = 1 * time.Second
-	client.RetryWaitMax = 10 * time.Second
-	client.HTTPClient.Timeout = time.Duration(timeout) * time.Second
-	client.Logger = logger
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Second,
+	}
 
 	// Normalize server URL: strip trailing slash for consistent URL building
 	serverURL := strings.TrimRight(config.IosOcrServerURL, "/")
@@ -103,7 +100,7 @@ func (p *IosOcrProvider) ProcessImage(ctx context.Context, imageContent []byte, 
 	}
 
 	// Create HTTP request
-	req, err := retryablehttp.NewRequestWithContext(ctx, "POST", uploadURL, &requestBody)
+	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, &requestBody)
 	if err != nil {
 		logger.WithError(err).Error("Failed to create HTTP request")
 		return nil, fmt.Errorf("error creating iOS OCR request: %w", err)

--- a/ocr/iosocr_provider_test.go
+++ b/ocr/iosocr_provider_test.go
@@ -1,0 +1,172 @@
+package ocr
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupIosOcrTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(handler)
+}
+
+func newTestIosOcrProvider(serverURL string) *IosOcrProvider {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 0
+	client.Logger = nil
+
+	return &IosOcrProvider{
+		serverURL:  serverURL,
+		httpClient: client,
+	}
+}
+
+func TestIosOcrProvider_ProcessImage(t *testing.T) {
+	sampleImageContent := []byte("dummy image data")
+
+	tests := []struct {
+		name           string
+		mockHandler    func(w http.ResponseWriter, r *http.Request)
+		expectedResult *OCRResult
+		expectedErrStr string
+		checkRequest   func(r *http.Request)
+	}{
+		{
+			name: "Success Case",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/upload", r.URL.Path)
+				assert.Equal(t, "POST", r.Method)
+				assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+				resp := IosOcrUploadResponse{
+					Success:     true,
+					Message:     "File uploaded successfully",
+					OcrResult:   "Hello\nWorld",
+					ImageWidth:  1247,
+					ImageHeight: 648,
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedResult: &OCRResult{
+				Text: "Hello\nWorld",
+				Metadata: map[string]string{
+					"provider":     "ios_ocr",
+					"has_content":  "true",
+					"image_width":  "1247",
+					"image_height": "648",
+				},
+			},
+			checkRequest: func(r *http.Request) {
+				err := r.ParseMultipartForm(10 << 20)
+				assert.NoError(t, err)
+				f, fh, err := r.FormFile("file")
+				assert.NoError(t, err)
+				assert.NotNil(t, f)
+				assert.Equal(t, "document.png", fh.Filename)
+				fileContent, _ := io.ReadAll(f)
+				assert.Equal(t, sampleImageContent, fileContent)
+				f.Close()
+			},
+		},
+		{
+			name: "Success Case - Empty OCR Result",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := IosOcrUploadResponse{
+					Success:   true,
+					Message:   "File uploaded successfully",
+					OcrResult: "",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedResult: &OCRResult{
+				Text: "",
+				Metadata: map[string]string{
+					"provider":     "ios_ocr",
+					"has_content":  "false",
+					"image_width":  "0",
+					"image_height": "0",
+				},
+			},
+		},
+		{
+			name: "Server Returns Failure",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := IosOcrUploadResponse{
+					Success: false,
+					Message: "Error processing image",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			},
+			expectedErrStr: "iOS OCR Server processing failed: Error processing image",
+		},
+		{
+			name: "Non-OK HTTP Status",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("Internal Server Error"))
+			},
+			expectedErrStr: "iOS OCR Server returned status 500",
+		},
+		{
+			name: "Invalid JSON Response",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("this is not json"))
+			},
+			expectedErrStr: "error parsing iOS OCR JSON response",
+		},
+		{
+			name: "Server Connection Error",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+			},
+			expectedErrStr: "connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.checkRequest != nil {
+					tt.checkRequest(r)
+				}
+				tt.mockHandler(w, r)
+			})
+
+			server := setupIosOcrTestServer(t, checkedHandler)
+
+			serverURL := server.URL
+			if tt.name == "Server Connection Error" {
+				server.Close()
+			}
+
+			provider := newTestIosOcrProvider(serverURL)
+
+			if tt.name != "Server Connection Error" {
+				defer server.Close()
+			}
+
+			result, err := provider.ProcessImage(context.Background(), sampleImageContent, 1)
+
+			if tt.expectedErrStr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrStr)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}

--- a/ocr/iosocr_provider_test.go
+++ b/ocr/iosocr_provider_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,13 +17,9 @@ func setupIosOcrTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Ser
 }
 
 func newTestIosOcrProvider(serverURL string) *IosOcrProvider {
-	client := retryablehttp.NewClient()
-	client.RetryMax = 0
-	client.Logger = nil
-
 	return &IosOcrProvider{
 		serverURL:  serverURL,
-		httpClient: client,
+		httpClient: &http.Client{},
 	}
 }
 

--- a/ocr/provider.go
+++ b/ocr/provider.go
@@ -78,6 +78,10 @@ type Config struct {
 	DoclingOCRPipeline     string // Optional, defaults to "vlm"
 	DoclingOCREngine       string // Optional, defaults to "easyocr", if DoclingOCRPipeline == "standard"
 
+	// iOS OCR Server settings
+	IosOcrServerURL     string
+	IosOcrServerTimeout int // seconds, default 60
+
 	// OCR output options
 	EnableHOCR     bool   // Whether to generate hOCR data if supported by the provider
 	HOCROutputPath string // Where to save hOCR output files
@@ -141,6 +145,13 @@ func NewProvider(config Config) (Provider, error) {
 			"model": config.MistralModel,
 		}).Info("Using Mistral OCR provider")
 		return newMistralOCRProvider(config)
+
+	case "ios_ocr":
+		if config.IosOcrServerURL == "" {
+			return nil, fmt.Errorf("missing required iOS OCR Server URL (IOS_OCR_SERVER_URL)")
+		}
+		log.WithField("url", config.IosOcrServerURL).Info("Using iOS OCR Server provider")
+		return newIosOcrProvider(config)
 
 	default:
 		return nil, fmt.Errorf("unsupported OCR provider: %s", config.Provider)


### PR DESCRIPTION
## Summary

Adds a new OCR provider `ios_ocr` that sends document images to
[iOS OCR Server](https://apps.apple.com/ch/app/ocr-server/id6749533041) —
an iPhone app using Apple's Vision Framework for local, private OCR.

## Changes

- **New provider** `ocr/iosocr_provider.go`: sends multipart POST
  requests to the iOS OCR Server's `/upload` API, extracts the
  recognized text from `ocr_result` in the JSON response
- **Full test coverage** `ocr/iosocr_provider_test.go`: 6 test cases
  following existing provider patterns
- **Configuration**: `IOS_OCR_SERVER_URL` env var (required),
  `IOS_OCR_SERVER_TIMEOUT` (optional, default 60s)
- **Image mode only** — matches the iOS Server's capabilities
- **No breaking changes** — only additive changes to config/factory/maps
  in `ocr/provider.go` and `main.go`

## Testing

Tested successfully with real documents on an iPhone with multiple documents processed and OCR text written back to paperless-ngx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new iOS OCR Server provider option for image-only OCR processing.
  * Startup now enforces that the iOS OCR server URL is provided when selected.

* **Configuration**
  * New environment variables to set the iOS OCR server endpoint and request timeout.

* **Documentation**
  * README updated with setup, compatibility (image-only), and configuration guidance.

* **Tests**
  * Added tests covering provider request/response handling and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/icereed/paperless-gpt/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->