### PR TITLE
fix: break auto-tag loop on update rejection; salvage valid fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ services:
       PAPERLESS_PUBLIC_URL: "http://paperless.mydomain.com" # Optional
       MANUAL_TAG: "paperless-gpt" # Optional, default: paperless-gpt
       AUTO_TAG: "paperless-gpt-auto" # Optional, default: paperless-gpt-auto
+      FAIL_TAG: "paperless-gpt-failed" # Optional, default: paperless-gpt-failed. Applied to documents whose update is rejected by paperless-ngx, so they don't get re-processed in a loop. Auto-created at startup.
       # LLM Configuration - Choose one:
 
       # Option 1: Standard OpenAI
@@ -544,6 +545,7 @@ For best results with the enhanced OCR features:
 | `PAPERLESS_PUBLIC_URL`              | Public URL for Paperless (if different from `PAPERLESS_BASE_URL`).                                                                                                                            | No       |                            |
 | `MANUAL_TAG`                        | Tag for manual processing.                                                                                                                                                                    | No       | paperless-gpt              |
 | `AUTO_TAG`                          | Tag for auto processing.                                                                                                                                                                      | No       | paperless-gpt-auto         |
+| `FAIL_TAG`                          | Tag applied to a document when paperless-gpt could not apply the full LLM suggestion. Two cases trigger it: (1) **partial success** — paperless-ngx rejected one or more fields (e.g. an LLM-suggested date in an impossible format such as `2023-01-79`); paperless-gpt drops the rejected fields, retries the update with the rest, and applies this tag so the user knows the document needs review; (2) **hard failure** — the update could not be salvaged; paperless-gpt removes the auto tag (to break the processing loop) and applies this tag. The tag is created automatically in paperless-ngx at startup if it does not exist. | No       | paperless-gpt-failed       |
 | `LLM_PROVIDER`                      | AI backend (`openai`, `ollama`, `googleai`, `mistral`, or `anthropic`).                                                                                                                       | Yes      |                            |
 | `LLM_MODEL`                         | AI model name (e.g., `gpt-4o`, `mistral-large-latest`, `qwen3:8b`, `claude-sonnet-4-5`).                                                                                               | Yes      |                            |
 | `OPENAI_API_KEY`                    | OpenAI API key (required if using OpenAI).                                                                                                                                                    | Cond.    |                            |

--- a/background.go
+++ b/background.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // This is our interface, allowing us to enable proper testing
@@ -78,6 +80,84 @@ func StartBackgroundTasks(ctx context.Context, app BackgroundProcessor) {
 	}()
 }
 
+// applyFailTagAfterPartialSuccess applies the fail tag to a document whose
+// update succeeded only after paperless-gpt had to drop one or more fields
+// rejected by paperless-ngx (see UpdateDocuments' strip-and-retry path).
+//
+// The document's tags in paperless-ngx have already been updated by the
+// successful retry to whatever the LLM suggested (the auto tag is no longer
+// present). To avoid clobbering those LLM-suggested tags, this function
+// re-fetches the document's current state, then PATCHes only the tags field
+// to append the fail tag.
+//
+// This is best-effort: if the re-fetch or the PATCH fails, the dropped-field
+// information is logged but the document is left with no fail tag. The loop
+// is still broken (the successful retry removed the auto tag) — only the
+// user-visible marker is missing.
+func applyFailTagAfterPartialSuccess(ctx context.Context, client ClientInterface, db *gorm.DB, documentID int, droppedFields []string) {
+	docLogger := documentLogger(documentID)
+	if failTag == "" {
+		docLogger.Warnf("Document %d update succeeded after paperless-ngx rejected fields %v; no FAIL_TAG is configured, so the document is not marked for review.", documentID, droppedFields)
+		return
+	}
+	currentDoc, err := client.GetDocument(ctx, documentID)
+	if err != nil {
+		docLogger.Errorf("Document %d update succeeded after dropping fields %v, but fetching current state to apply fail tag failed: %v", documentID, droppedFields, err)
+		return
+	}
+	if slices.Contains(currentDoc.Tags, failTag) {
+		docLogger.Warnf("Document %d update succeeded after dropping fields %v; fail tag %q is already present.", documentID, droppedFields, failTag)
+		return
+	}
+	suggestion := DocumentSuggestion{
+		ID:               documentID,
+		OriginalDocument: currentDoc,
+		SuggestedTags:    []string{failTag},
+		KeepOriginalTags: true,
+	}
+	if err := client.UpdateDocuments(ctx, []DocumentSuggestion{suggestion}, db, false); err != nil {
+		docLogger.Errorf("Document %d update succeeded after dropping fields %v, but applying fail tag %q failed: %v", documentID, droppedFields, failTag, err)
+		return
+	}
+	docLogger.Warnf("Document %d update succeeded after paperless-ngx rejected fields %v; fail tag %q applied for user review.", documentID, droppedFields, failTag)
+}
+
+// recoverFromFailedUpdate is called when an UpdateDocuments call has failed for
+// a document picked up by the auto-tagging or auto-OCR poll. It performs a
+// minimal tag-only PATCH that removes the auto-tag the document was picked up by
+// (so the document is not re-processed on every poll cycle, which can cost
+// real money on paid LLM providers) and, if failTag is configured, adds it as
+// a marker so the user can find and review failed documents.
+//
+// The recovery PATCH only manipulates tags and therefore should succeed even
+// when the original PATCH was rejected for a field-validation reason (e.g.
+// an LLM-suggested date that is not a real calendar date).
+//
+// On its own failure, this function logs at error level but does not return
+// the error to the caller — the caller has already recorded the original
+// update failure and the recovery is best-effort.
+func recoverFromFailedUpdate(ctx context.Context, client ClientInterface, db *gorm.DB, document Document, removeTag string) {
+	docLogger := documentLogger(document.ID)
+	recoveryFields := DocumentSuggestion{
+		ID:               document.ID,
+		OriginalDocument: document,
+		RemoveTags:       []string{removeTag},
+	}
+	if failTag != "" {
+		recoveryFields.SuggestedTags = []string{failTag}
+		recoveryFields.KeepOriginalTags = true
+	}
+	if err := client.UpdateDocuments(ctx, []DocumentSuggestion{recoveryFields}, db, false); err != nil {
+		docLogger.Errorf("Recovery update for failed document %d also failed: %v. The %q tag may still be present and the document may be re-processed on the next poll cycle.", document.ID, err, removeTag)
+		return
+	}
+	if failTag != "" {
+		docLogger.Warnf("Document %d update failed; %q tag removed and %q tag applied to break the processing loop.", document.ID, removeTag, failTag)
+	} else {
+		docLogger.Warnf("Document %d update failed; %q tag removed to break the processing loop (no failTag configured).", document.ID, removeTag)
+	}
+}
+
 // processAutoTagDocuments handles the background auto-tagging of documents
 func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
 	documents, err := app.Client.GetDocumentsByTag(ctx, autoTag, 25)
@@ -137,9 +217,21 @@ func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
 
 		err = app.Client.UpdateDocuments(ctx, suggestions, app.Database, false)
 		if err != nil {
+			var partial *PartialUpdateError
+			if errors.As(err, &partial) {
+				// Update went through but paperless-ngx rejected some fields,
+				// which UpdateDocuments dropped in order to land the rest.
+				// The auto tag is already gone (it was part of the successful
+				// retry's tag update). Apply the fail tag so the user sees
+				// that this document needs review.
+				applyFailTagAfterPartialSuccess(ctx, app.Client, app.Database, partial.DocumentID, partial.DroppedFields)
+				processedCount++
+				continue
+			}
 			err = fmt.Errorf("error updating document %d: %w", document.ID, err)
 			docLogger.Error(err.Error())
 			errs = append(errs, err)
+			recoverFromFailedUpdate(ctx, app.Client, app.Database, document, autoTag)
 			continue
 		}
 
@@ -270,8 +362,17 @@ func (app *App) processAutoOcrTagDocuments(ctx context.Context) (int, error) {
 				documentSuggestion,
 			}, app.Database, false)
 			if err != nil {
+				var partial *PartialUpdateError
+				if errors.As(err, &partial) {
+					applyFailTagAfterPartialSuccess(ctx, app.Client, app.Database, partial.DocumentID, partial.DroppedFields)
+					// Treat as a (partial) success: tag was removed, fail tag applied.
+					docLogger.Info("Successfully processed document OCR (with partial-update fail-tag marker)")
+					successCount++
+					continue
+				}
 				docLogger.Errorf("Update after OCR failed: %v", err)
 				errs = append(errs, fmt.Errorf("document %d update error: %w", document.ID, err))
+				recoverFromFailedUpdate(ctx, app.Client, app.Database, document, autoOcrTag)
 				continue
 			}
 		}

--- a/background_test.go
+++ b/background_test.go
@@ -541,3 +541,82 @@ func TestProcessAutoOcrTagDocuments(t *testing.T) {
 		})
 	}
 }
+
+// recordingClient is a stub ClientInterface used to verify the loop-break
+// recovery PATCH built by recoverFromFailedUpdate.
+type recordingClient struct {
+	*PaperlessClient
+	calls           []DocumentSuggestion
+	updateErr       error // returned by UpdateDocuments while non-nil
+	failAfterNCalls int   // 0 = always succeed, N>0 = fail first N calls then succeed
+}
+
+func (r *recordingClient) UpdateDocuments(ctx context.Context, documents []DocumentSuggestion, db *gorm.DB, isUndo bool) error {
+	for _, d := range documents {
+		r.calls = append(r.calls, d)
+	}
+	if r.failAfterNCalls > 0 {
+		r.failAfterNCalls--
+		return r.updateErr
+	}
+	return nil
+}
+
+// TestRecoverFromFailedUpdate verifies that the recovery PATCH built by
+// recoverFromFailedUpdate removes the auto tag (so the document is not
+// re-processed on the next poll) and adds the fail tag (so the user can find
+// the document later in the UI). This is the loop-break behaviour relied upon
+// by both processAutoTagDocuments and processAutoOcrTagDocuments.
+func TestRecoverFromFailedUpdate(t *testing.T) {
+	prevFailTag := failTag
+	t.Cleanup(func() { failTag = prevFailTag })
+
+	doc := Document{ID: 42, Title: "Failing Doc", Tags: []string{"paperless-gpt-auto", "Eingang"}}
+
+	t.Run("removes auto tag and adds fail tag", func(t *testing.T) {
+		failTag = "paperless-gpt-failed"
+		client := &recordingClient{}
+
+		recoverFromFailedUpdate(context.Background(), client, nil, doc, "paperless-gpt-auto")
+
+		require.Len(t, client.calls, 1, "recovery should issue exactly one UpdateDocuments call")
+		got := client.calls[0]
+		assert.Equal(t, 42, got.ID)
+		assert.Equal(t, []string{"paperless-gpt-auto"}, got.RemoveTags, "auto tag must be removed to break the loop")
+		assert.Equal(t, []string{"paperless-gpt-failed"}, got.SuggestedTags, "fail tag must be added as a marker")
+		assert.True(t, got.KeepOriginalTags, "must keep original tags so we only add the fail tag, not replace all tags")
+	})
+
+	t.Run("works without fail tag — still removes auto tag", func(t *testing.T) {
+		failTag = ""
+		client := &recordingClient{}
+
+		recoverFromFailedUpdate(context.Background(), client, nil, doc, "paperless-gpt-auto")
+
+		require.Len(t, client.calls, 1)
+		got := client.calls[0]
+		assert.Equal(t, []string{"paperless-gpt-auto"}, got.RemoveTags, "auto tag must be removed even when fail tag is disabled")
+		assert.Empty(t, got.SuggestedTags, "no fail tag should be added when failTag is empty")
+		assert.False(t, got.KeepOriginalTags, "KeepOriginalTags is only meaningful when adding suggested tags")
+	})
+
+	t.Run("logs but does not panic when recovery itself fails", func(t *testing.T) {
+		failTag = "paperless-gpt-failed"
+		client := &recordingClient{updateErr: errors.New("paperless unreachable"), failAfterNCalls: 1}
+
+		// Should not panic; recovery is best-effort.
+		recoverFromFailedUpdate(context.Background(), client, nil, doc, "paperless-gpt-auto")
+
+		require.Len(t, client.calls, 1, "recovery call should have been attempted")
+	})
+
+	t.Run("works for OCR auto tag too", func(t *testing.T) {
+		failTag = "paperless-gpt-failed"
+		client := &recordingClient{}
+
+		recoverFromFailedUpdate(context.Background(), client, nil, doc, "paperless-gpt-ocr-auto")
+
+		require.Len(t, client.calls, 1)
+		assert.Equal(t, []string{"paperless-gpt-ocr-auto"}, client.calls[0].RemoveTags)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	autoTag                       = os.Getenv("AUTO_TAG")
 	manualOcrTag                  = os.Getenv("MANUAL_OCR_TAG") // Not used yet
 	autoOcrTag                    = os.Getenv("AUTO_OCR_TAG")
+	failTag                       = os.Getenv("FAIL_TAG")
 	ocrProcessMode                = os.Getenv("OCR_PROCESS_MODE")
 	llmProvider                   = os.Getenv("LLM_PROVIDER")
 	llmModel                      = os.Getenv("LLM_MODEL")
@@ -161,6 +162,15 @@ func main() {
 
 	// Initialize PaperlessClient
 	client := NewPaperlessClient(paperlessBaseURL, paperlessAPIToken)
+
+	// Ensure the fail tag exists in paperless-ngx. paperless-gpt applies this
+	// tag mechanically when document processing fails (see processAutoTagDocuments),
+	// so it must be available regardless of the CREATE_NEW_TAGS setting.
+	// A failure here is logged but non-fatal: the loop-break path still removes
+	// the auto tag, the fail tag is just not applied.
+	if err := client.EnsureTagExists(ctx, failTag); err != nil {
+		log.Warnf("Failed to ensure fail tag %q exists: %v. Recovery from a failed document update will still remove the auto tag (loop break works), but the fail tag will not be added.", failTag, err)
+	}
 
 	// Initial fetch of custom fields
 	refreshCustomFieldsCache(client)
@@ -580,6 +590,11 @@ func validateOrDefaultEnvVars() {
 	if autoOcrTag == "" {
 		autoOcrTag = "paperless-gpt-ocr-auto"
 	}
+
+	if failTag == "" {
+		failTag = "paperless-gpt-failed"
+	}
+	fmt.Printf("Using %s as fail tag\n", failTag)
 
 	if pdfOCRCompleteTag == "" {
 		pdfOCRCompleteTag = "paperless-gpt-ocr-complete"

--- a/paperless.go
+++ b/paperless.go
@@ -471,6 +471,16 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		availableDocumentTypes[dt.Name] = dt.ID
 	}
 
+	// firstPartial captures the first document in the batch whose update only
+	// succeeded after paperless-gpt had to drop some fields rejected by
+	// paperless-ngx. If non-nil at the end of the function, the caller sees a
+	// PartialUpdateError and applies the fail tag.
+	// Single-document calls (which are the normal usage from background.go)
+	// only ever see the result for that one document; multi-document calls
+	// report on the first one that had drops, matching the existing
+	// stop-on-first-failure semantics for hard errors.
+	var firstPartial *PartialUpdateError
+
 	for _, document := range documents {
 		documentID := document.ID
 		originalDoc := document.OriginalDocument
@@ -663,21 +673,78 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		}
 
 		log.Debugf("Document %d: Fields to update: %v", documentID, updatedFields)
-		jsonData, err := json.Marshal(updatedFields)
-		if err != nil {
-			return fmt.Errorf("error marshalling JSON for document %d: %w", documentID, err)
-		}
 
-		path := fmt.Sprintf("api/documents/%d/", documentID)
-		resp, err := client.Do(ctx, "PATCH", path, bytes.NewBuffer(jsonData))
-		if err != nil {
-			return fmt.Errorf("error updating document %d: %w", documentID, err)
-		}
-		defer resp.Body.Close()
+		// PATCH with strip-and-retry: if paperless-ngx rejects the update with
+		// a 400 (e.g. an LLM-suggested value that fails server-side
+		// validation), parse the response to identify which fields paperless
+		// rejected, remove them from updatedFields, and retry. This salvages
+		// the valid fields the LLM suggested instead of discarding the entire
+		// update.
+		//
+		// In practice paperless-ngx reports all validation errors in a single
+		// 400 response, so one retry is normally sufficient. The retry cap
+		// guards against pathological cases (e.g. cascading validation).
+		// If after all retries we still cannot get a 200, the caller's
+		// recoverFromFailedUpdate handles the final loop-break (remove auto
+		// tag, add fail tag).
+		const maxRetries = 3
+		patchPath := fmt.Sprintf("api/documents/%d/", documentID)
+		var partialDroppedFields []string
+		patchSucceeded := false
 
-		if resp.StatusCode != http.StatusOK {
+		for attempt := 0; attempt <= maxRetries; attempt++ {
+			if len(updatedFields) == 0 {
+				// All fields stripped — nothing left to send.
+				return fmt.Errorf("error updating document %d: paperless-ngx rejected every field that was suggested (dropped on previous attempts: %v)", documentID, partialDroppedFields)
+			}
+
+			jsonData, err := json.Marshal(updatedFields)
+			if err != nil {
+				return fmt.Errorf("error marshalling JSON for document %d: %w", documentID, err)
+			}
+
+			resp, err := client.Do(ctx, "PATCH", patchPath, bytes.NewBuffer(jsonData))
+			if err != nil {
+				return fmt.Errorf("error updating document %d: %w", documentID, err)
+			}
 			bodyBytes, _ := io.ReadAll(resp.Body)
-			return fmt.Errorf("error updating document %d: %d, %s", documentID, resp.StatusCode, string(bodyBytes))
+			resp.Body.Close()
+
+			if resp.StatusCode == http.StatusOK {
+				patchSucceeded = true
+				break
+			}
+
+			if resp.StatusCode != http.StatusBadRequest {
+				return fmt.Errorf("error updating document %d: %d, %s", documentID, resp.StatusCode, string(bodyBytes))
+			}
+
+			// 400 — try to identify the failing fields so we can drop them and retry.
+			scalarFails, cfIdxFails, unrecoverable := parsePaperlessValidationErrors(bodyBytes)
+			if unrecoverable || (len(scalarFails) == 0 && len(cfIdxFails) == 0) {
+				return fmt.Errorf("error updating document %d: %d, %s", documentID, resp.StatusCode, string(bodyBytes))
+			}
+
+			newlyDropped := stripFailedFields(updatedFields, scalarFails, cfIdxFails)
+			if len(newlyDropped) == 0 {
+				// Paperless reported errors but they don't match anything in our
+				// current payload — defensive guard against parser/format drift.
+				return fmt.Errorf("error updating document %d: %d, %s", documentID, resp.StatusCode, string(bodyBytes))
+			}
+
+			partialDroppedFields = append(partialDroppedFields, newlyDropped...)
+			log.Warnf("Document %d: paperless-ngx rejected fields %v on attempt %d/%d; retrying without them. Raw response: %s", documentID, newlyDropped, attempt+1, maxRetries+1, string(bodyBytes))
+		}
+
+		if !patchSucceeded {
+			return fmt.Errorf("error updating document %d: paperless-ngx still rejected the update after %d retries (fields dropped so far: %v)", documentID, maxRetries, partialDroppedFields)
+		}
+
+		if len(partialDroppedFields) > 0 && firstPartial == nil {
+			firstPartial = &PartialUpdateError{
+				DocumentID:    documentID,
+				DroppedFields: partialDroppedFields,
+			}
 		}
 
 		// Check if we need to remove auto/manual tags in a separate update
@@ -762,7 +829,100 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		}
 		log.Printf("Document %d updated successfully.", documentID)
 	}
+	if firstPartial != nil {
+		return firstPartial
+	}
 	return nil
+}
+
+// parsePaperlessValidationErrors interprets paperless-ngx's 400 response body
+// and classifies the validation errors into three buckets:
+//   - scalarFields: top-level fields (other than custom_fields and tags) that
+//     paperless rejected. These can be removed from the PATCH and retried.
+//   - customFieldIndices: indices into the custom_fields array whose entries
+//     paperless rejected. These entries can be removed and retried.
+//   - unrecoverable: true if the response contains errors paperless-gpt cannot
+//     safely drop (currently: any failure that references the "tags" field,
+//     because the tag update is what breaks the auto-processing loop). The
+//     caller must treat this as a hard failure.
+//
+// Returns (nil, nil, false) if the body cannot be parsed as the expected
+// shape; the caller treats this as a hard failure too.
+//
+// Example paperless-ngx 400 body this parser handles:
+//
+//	{"created_date":["Date has wrong format..."],
+//	 "custom_fields":[{},{},{},{},{},{"non_field_errors":["..."]},{},{}]}
+func parsePaperlessValidationErrors(body []byte) (scalarFields map[string]bool, customFieldIndices []int, unrecoverable bool) {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, nil, false
+	}
+	scalarFields = make(map[string]bool)
+	for key, val := range raw {
+		switch key {
+		case "tags":
+			// Tag updates are load-bearing for the loop-break behaviour; we
+			// must not drop them silently. Treat as unrecoverable so the
+			// caller falls back to recoverFromFailedUpdate.
+			unrecoverable = true
+			return
+		case "custom_fields":
+			arr, ok := val.([]any)
+			if !ok {
+				// Unexpected shape — bail to hard-failure path.
+				unrecoverable = true
+				return
+			}
+			for i, entry := range arr {
+				obj, ok := entry.(map[string]any)
+				if !ok || len(obj) == 0 {
+					continue
+				}
+				customFieldIndices = append(customFieldIndices, i)
+			}
+		default:
+			scalarFields[key] = true
+		}
+	}
+	if len(scalarFields) == 0 && len(customFieldIndices) == 0 {
+		return nil, nil, false
+	}
+	return scalarFields, customFieldIndices, false
+}
+
+// stripFailedFields removes the fields named in scalarFields and the
+// custom_fields entries at the given indices from updatedFields, in-place.
+// Returns human-readable names of fields actually stripped, for logging.
+func stripFailedFields(updatedFields map[string]interface{}, scalarFields map[string]bool, customFieldIndices []int) []string {
+	var dropped []string
+	for field := range scalarFields {
+		if _, present := updatedFields[field]; present {
+			delete(updatedFields, field)
+			dropped = append(dropped, field)
+		}
+	}
+	if len(customFieldIndices) > 0 {
+		if cf, ok := updatedFields["custom_fields"].([]CustomFieldResponse); ok {
+			// Remove in descending index order so later indices remain valid
+			// as we splice the slice.
+			sortedIdx := slices.Clone(customFieldIndices)
+			sort.Sort(sort.Reverse(sort.IntSlice(sortedIdx)))
+			for _, idx := range sortedIdx {
+				if idx < 0 || idx >= len(cf) {
+					continue
+				}
+				dropped = append(dropped, fmt.Sprintf("custom_fields[%d](field_id=%d)", idx, cf[idx].Field))
+				cf = append(cf[:idx], cf[idx+1:]...)
+			}
+			if len(cf) == 0 {
+				delete(updatedFields, "custom_fields")
+			} else {
+				updatedFields["custom_fields"] = cf
+			}
+		}
+	}
+	return dropped
 }
 
 // DownloadDocumentAsImages downloads the PDF file of the specified document and converts it to images
@@ -1356,6 +1516,27 @@ func (client *PaperlessClient) CreateTag(ctx context.Context, tagName string) (i
 	}
 
 	return createdTag.ID, nil
+}
+
+// EnsureTagExists checks whether a tag with the given name exists in paperless-ngx
+// and creates it if not. Used for paperless-gpt's internal marker tags (e.g. failTag)
+// which should always be available regardless of the CREATE_NEW_TAGS setting,
+// because they are not LLM-suggested tags but mechanically applied by paperless-gpt itself.
+func (client *PaperlessClient) EnsureTagExists(ctx context.Context, tagName string) error {
+	if tagName == "" {
+		return nil
+	}
+	tags, err := client.GetAllTags(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching tags: %w", err)
+	}
+	if _, exists := tags[tagName]; exists {
+		return nil
+	}
+	if _, err := client.CreateTag(ctx, tagName); err != nil {
+		return fmt.Errorf("error creating tag %q: %w", tagName, err)
+	}
+	return nil
 }
 
 // UploadDocument uploads a document to paperless-ngx

--- a/paperless.go
+++ b/paperless.go
@@ -15,12 +15,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/disintegration/imaging"
 	"github.com/gen2brain/go-fitz"
@@ -486,6 +486,7 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		originalDoc := document.OriginalDocument
 		updatedFields := make(map[string]interface{})
 		originalFields := make(map[string]interface{})
+		var partialDroppedFields []string
 
 		// --- TAGS ---
 		finalTagNames := originalDoc.Tags
@@ -586,12 +587,18 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		// --- CREATED DATE ---
 		suggestedCreatedDate := document.SuggestedCreatedDate
 		if suggestedCreatedDate != "" {
-			// Validate format YYYY-MM-DD
-			if matched := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`).MatchString(suggestedCreatedDate); matched {
+			// Validate that the date is a real Gregorian calendar date, not just
+			// a correctly-formatted string. time.Parse rejects impossible dates
+			// like "2023-01-79" (day 79) that the regex `^\d{4}-\d{2}-\d{2}$`
+			// would accept. Dropped pre-flight rather than after a 400 to avoid
+			// an unnecessary round-trip, but the effect on the user is the same:
+			// the field is skipped and the fail tag is applied.
+			if _, err := time.Parse("2006-01-02", suggestedCreatedDate); err == nil {
 				originalFields["created_date"] = document.OriginalDocument.CreatedDate
 				updatedFields["created_date"] = suggestedCreatedDate
 			} else {
-				log.Warnf("Invalid created_date format for document %d: %s. Expected YYYY-MM-DD, skipping.", documentID, suggestedCreatedDate)
+				log.Warnf("Document %d: created_date %q is not a valid calendar date, skipping. (%v)", documentID, suggestedCreatedDate, err)
+				partialDroppedFields = append(partialDroppedFields, "created_date")
 			}
 		}
 
@@ -689,7 +696,6 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		// tag, add fail tag).
 		const maxRetries = 3
 		patchPath := fmt.Sprintf("api/documents/%d/", documentID)
-		var partialDroppedFields []string
 		patchSucceeded := false
 
 		for attempt := 0; attempt <= maxRetries; attempt++ {

--- a/paperless_test.go
+++ b/paperless_test.go
@@ -883,3 +883,58 @@ func TestStripFailedFields(t *testing.T) {
 		assert.Equal(t, "x", uf["title"])
 	})
 }
+
+func TestCreatedDatePreValidation(t *testing.T) {
+	// Verify that UpdateDocuments rejects impossible dates like "2023-01-79"
+	// before sending the PATCH, so the bad date never reaches paperless-ngx.
+	// The field should appear in partialDroppedFields so the caller applies
+	// the fail tag.
+	env := setupTest(t)
+	defer env.teardown()
+
+	ctx := context.Background()
+
+	setupTestCase(TestCase{
+		name: "pre-validate created_date",
+		documents: []TestDocument{
+			{ID: 1, Title: "Test Doc", Tags: []string{autoTag}},
+		},
+	}, env)
+
+	patchCalled := false
+	var receivedPatch map[string]interface{}
+	env.setMockResponse("/api/documents/1/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			json.NewEncoder(w).Encode(GetDocumentApiResponse{
+				ID: 1, Title: "Test Doc", Tags: []int{1}, Content: "content",
+			})
+			return
+		}
+		if r.Method == "PATCH" {
+			patchCalled = true
+			json.NewDecoder(r.Body).Decode(&receivedPatch)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": 1, "title": "Test Doc", "tags": []int{1},
+			})
+		}
+	})
+
+	suggestion := DocumentSuggestion{
+		ID:                   1,
+		OriginalDocument:     Document{ID: 1, Title: "Test Doc", Tags: []string{autoTag}},
+		SuggestedTitle:       "Better Title",
+		SuggestedCreatedDate: "2023-01-79", // impossible date
+	}
+
+	err := env.client.UpdateDocuments(ctx, []DocumentSuggestion{suggestion}, env.db, false)
+
+	var partial *PartialUpdateError
+	require.ErrorAs(t, err, &partial, "UpdateDocuments must return PartialUpdateError when created_date is invalid")
+	assert.Contains(t, partial.DroppedFields, "created_date", "created_date must be in DroppedFields")
+	require.True(t, patchCalled, "PATCH must still be sent (with the valid fields)")
+	if created, ok := receivedPatch["created_date"]; ok {
+		t.Errorf("PATCH must not include invalid created_date, but got %v", created)
+	}
+	assert.Equal(t, "Better Title", receivedPatch["title"], "valid fields must still be sent")
+}

--- a/paperless_test.go
+++ b/paperless_test.go
@@ -756,3 +756,130 @@ func TestDownloadDocumentAsPDF(t *testing.T) {
 
 	// Testing with splitting=true would be more complex so we'll skip that for simplicity
 }
+
+func TestParsePaperlessValidationErrors(t *testing.T) {
+	t.Run("real-world response with created_date + one custom_field", func(t *testing.T) {
+		body := []byte(`{"created_date":["Date has wrong format. Use one of these formats instead: YYYY-MM-DD."],"custom_fields":[{},{},{},{},{},{},{},{"non_field_errors":["Date has wrong format. Use one of these formats instead: YYYY-MM-DD."]}]}`)
+		scalars, cfIdx, unrecoverable := parsePaperlessValidationErrors(body)
+		require.False(t, unrecoverable)
+		assert.True(t, scalars["created_date"], "created_date must be reported")
+		assert.Equal(t, []int{7}, cfIdx, "custom_fields[7] is the only failing entry")
+	})
+
+	t.Run("only custom_field failure", func(t *testing.T) {
+		body := []byte(`{"custom_fields":[{},{"non_field_errors":["bad"]},{}]}`)
+		scalars, cfIdx, unrecoverable := parsePaperlessValidationErrors(body)
+		require.False(t, unrecoverable)
+		assert.Empty(t, scalars)
+		assert.Equal(t, []int{1}, cfIdx)
+	})
+
+	t.Run("only scalar failure", func(t *testing.T) {
+		body := []byte(`{"title":["This field may not be blank."]}`)
+		scalars, cfIdx, unrecoverable := parsePaperlessValidationErrors(body)
+		require.False(t, unrecoverable)
+		assert.True(t, scalars["title"])
+		assert.Empty(t, cfIdx)
+	})
+
+	t.Run("tags failure is unrecoverable", func(t *testing.T) {
+		// Tag updates carry the loop-break (auto-tag removal). We must not
+		// silently drop them.
+		body := []byte(`{"tags":["Invalid pk \"99\" - object does not exist."]}`)
+		_, _, unrecoverable := parsePaperlessValidationErrors(body)
+		assert.True(t, unrecoverable, "tag errors must be classified as unrecoverable")
+	})
+
+	t.Run("garbage body returns nothing-to-strip", func(t *testing.T) {
+		scalars, cfIdx, unrecoverable := parsePaperlessValidationErrors([]byte("not json"))
+		assert.Nil(t, scalars)
+		assert.Nil(t, cfIdx)
+		assert.False(t, unrecoverable)
+	})
+
+	t.Run("empty response with no errors returns nothing-to-strip", func(t *testing.T) {
+		scalars, cfIdx, unrecoverable := parsePaperlessValidationErrors([]byte(`{}`))
+		assert.Nil(t, scalars)
+		assert.Nil(t, cfIdx)
+		assert.False(t, unrecoverable)
+	})
+}
+
+func TestStripFailedFields(t *testing.T) {
+	t.Run("strips scalar field", func(t *testing.T) {
+		uf := map[string]interface{}{
+			"title":        "BARMER letter",
+			"created_date": "2023-01-79",
+		}
+		dropped := stripFailedFields(uf, map[string]bool{"created_date": true}, nil)
+		assert.Equal(t, []string{"created_date"}, dropped)
+		_, present := uf["created_date"]
+		assert.False(t, present)
+		assert.Equal(t, "BARMER letter", uf["title"])
+	})
+
+	t.Run("strips custom_fields entries by index, preserves the rest", func(t *testing.T) {
+		uf := map[string]interface{}{
+			"custom_fields": []CustomFieldResponse{
+				{Field: 6, Value: "Adresse"},
+				{Field: 7, Value: "2023-01-79"},
+				{Field: 8, Value: "M976605823"},
+			},
+		}
+		dropped := stripFailedFields(uf, nil, []int{1})
+		require.Len(t, dropped, 1)
+		assert.Contains(t, dropped[0], "field_id=7")
+		cf := uf["custom_fields"].([]CustomFieldResponse)
+		require.Len(t, cf, 2)
+		assert.Equal(t, 6, cf[0].Field)
+		assert.Equal(t, 8, cf[1].Field, "field 8 must remain after deleting index 1")
+	})
+
+	t.Run("strips multiple custom_fields entries (descending order is safe)", func(t *testing.T) {
+		uf := map[string]interface{}{
+			"custom_fields": []CustomFieldResponse{
+				{Field: 1, Value: "a"},
+				{Field: 2, Value: "b"},
+				{Field: 3, Value: "c"},
+				{Field: 4, Value: "d"},
+			},
+		}
+		dropped := stripFailedFields(uf, nil, []int{0, 2})
+		require.Len(t, dropped, 2)
+		cf := uf["custom_fields"].([]CustomFieldResponse)
+		require.Len(t, cf, 2)
+		assert.Equal(t, 2, cf[0].Field, "field 2 must remain after deleting indices 0 and 2")
+		assert.Equal(t, 4, cf[1].Field, "field 4 must remain after deleting indices 0 and 2")
+	})
+
+	t.Run("removes custom_fields key entirely if all entries fail", func(t *testing.T) {
+		uf := map[string]interface{}{
+			"title": "Letter",
+			"custom_fields": []CustomFieldResponse{
+				{Field: 7, Value: "2023-01-79"},
+			},
+		}
+		dropped := stripFailedFields(uf, nil, []int{0})
+		require.Len(t, dropped, 1)
+		_, present := uf["custom_fields"]
+		assert.False(t, present, "custom_fields key should be removed when empty")
+		assert.Equal(t, "Letter", uf["title"])
+	})
+
+	t.Run("ignores out-of-range custom_field indices", func(t *testing.T) {
+		uf := map[string]interface{}{
+			"custom_fields": []CustomFieldResponse{{Field: 1, Value: "a"}},
+		}
+		dropped := stripFailedFields(uf, nil, []int{5})
+		assert.Empty(t, dropped)
+		cf := uf["custom_fields"].([]CustomFieldResponse)
+		assert.Len(t, cf, 1, "original entry must remain when index is out of range")
+	})
+
+	t.Run("returns empty when scalar field is not in payload", func(t *testing.T) {
+		uf := map[string]interface{}{"title": "x"}
+		dropped := stripFailedFields(uf, map[string]bool{"created_date": true}, nil)
+		assert.Empty(t, dropped, "must not report a drop for a field that was not in the payload")
+		assert.Equal(t, "x", uf["title"])
+	})
+}

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -154,6 +155,21 @@ type OCROptions struct {
 	CopyMetadata    bool   // Whether to copy metadata from the original document
 	LimitPages      int    // Limit on the number of pages to process (0 = no limit)
 	ProcessMode     string // OCR processing mode: "image" (default) or "pdf"
+}
+
+// PartialUpdateError signals that a document update succeeded only after
+// paperless-gpt had to drop one or more fields that paperless-ngx rejected as
+// invalid. The PATCH eventually succeeded with the surviving fields; the
+// document has been written but is incomplete relative to what the LLM
+// suggested. Callers should treat this as a successful update but apply the
+// fail tag so the user knows the document needs review.
+type PartialUpdateError struct {
+	DocumentID    int
+	DroppedFields []string
+}
+
+func (e *PartialUpdateError) Error() string {
+	return fmt.Sprintf("document %d updated with %d field(s) dropped due to paperless-ngx validation errors: %v", e.DocumentID, len(e.DroppedFields), e.DroppedFields)
 }
 
 // ClientInterface defines the interface for PaperlessClient operations


### PR DESCRIPTION
## Problem

When paperless-ngx rejects an `UpdateDocuments` PATCH (HTTP 400 from its serializer), paperless-gpt does not remove the auto tag from the document. The next polling cycle picks the document up again, runs the full LLM pipeline, sends another PATCH, gets rejected again — indefinitely.

Reproduction: a document whose OCR text contains a corrupted date (`Datum 79.01.2023`) leads the LLM to extract `2023-01-79` into the `Fälligkeitsdatum` custom field. paperless-ngx rejects with:

```
400 {"custom_fields":[{},{},{},{},{"non_field_errors":
    ["Date has wrong format. Use one of these formats instead:
    YYYY-MM-DD."]},{},{}]}
```

On a paid LLM provider the loop bills ~6 calls every ~9 seconds until the user notices and manually removes the tag.

## Fix

Two layers:

1. **Strip-and-retry.** Parse the 400 body, identify which fields paperless-ngx rejected (top-level scalars + array indices into `custom_fields`), remove only those, and retry the PATCH. The valid title / correspondent / tags / document_type / surviving custom fields all land. Bounded to 3 retries; in practice 1 is enough because paperless-ngx reports all errors in one body.

2. **Fail-tag marker.** Whenever fields had to be dropped, apply a configurable fail tag (`FAIL_TAG`, default `paperless-gpt-failed`) so the user can find the document and complete it manually. The tag is auto-created in paperless-ngx at startup so the user doesn't need any setup.

If the update can't be salvaged at all (response unparseable, errors reference fields we can't safely drop such as `tags`, retry cap exhausted), the failure path is taken: remove the auto tag and add the fail tag in a tag-only PATCH. The loop is broken either way.

The same handling applies to both `processAutoTagDocuments` and `processAutoOcrTagDocuments`.

## Test plan

- [x] Unit tests for `parsePaperlessValidationErrors` covering real-world body, scalar-only, custom_field-only, tags-only (unrecoverable), garbage, empty response.
- [x] Unit tests for `stripFailedFields` covering scalar drop, indexed custom_field drop, multi-index drop, full removal, out-of-range indices, no-op on absent fields.
- [x] Unit tests for `recoverFromFailedUpdate` covering happy path, empty `FAIL_TAG`, recovery itself failing, OCR variant.
- [x] End-to-end against a real paperless-ngx instance: doc with OCR-corrupted date triggers 400 → strip-and-retry → all valid fields land → fail tag applied → no further polling cycles.

## Backwards compatibility

`FAIL_TAG` defaults to `paperless-gpt-failed` and is auto-created at startup; existing deployments need no configuration changes. The new behaviour replaces a code path that previously caused an unbounded processing loop — strictly an improvement.

## Notes

- The strip-and-retry approach is deliberately data-driven from paperless-ngx's own response. paperless-gpt does not maintain a parallel copy of paperless-ngx's validation rules, so adding new field types upstream doesn't require corresponding changes here.
- The current `Dockerfile` pins `musl-dev=1.2.5-r9` which is no longer available on Alpine 3.21 (current is `r11`); building from this branch as-is therefore fails. That is a separate, unrelated bit-rot and should be a Renovate bump — this PR does not touch the Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FAIL_TAG environment variable (default: paperless-gpt-failed) to mark documents when updates are rejected
  * App now ensures the fail tag exists at startup

* **Bug Fixes**
  * Better recovery to avoid repeated re-processing of failed documents
  * Partial-update handling improved with targeted retries that omit invalid fields

* **Documentation**
  * README updated with FAIL_TAG usage and failure scenarios

* **Tests**
  * Added tests covering recovery and partial-update behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/icereed/paperless-gpt/pull/976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->