### PR TITLE
fix: normalize monetary custom field values before update

### DIFF
--- a/normalize_monetary.go
+++ b/normalize_monetary.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// normalizeMonetary turns an LLM-emitted monetary value into the
+// Paperless-canonical form: optional 3-letter currency code immediately
+// followed by a plain number with exactly two decimals and no thousands
+// separators (e.g. "USD1053.52", "1053.52").
+//
+// It disambiguates US thousands ("1,053.52") from EU decimal ("1.053,52")
+// instead of doing a naive comma->dot swap, which would corrupt US values:
+//
+//   - If both '.' and ',' are present, whichever appears LAST is the decimal
+//     separator; the other is the thousands separator.
+//   - If only one is present, it's the decimal when 1-2 digits follow it,
+//     or a thousands separator when 3 digits follow it (and the integer part
+//     has 1-3 digits).
+//
+// If the input cannot be confidently parsed, it is returned unchanged so
+// paperless-ngx's validation surfaces the bad value rather than silently
+// corrupting it.
+func normalizeMonetary(value string) string {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return value
+	}
+
+	currency, numeric := splitCurrencyAndNumber(raw)
+	if numeric == "" {
+		return value
+	}
+
+	parsed, ok := parseAmount(numeric)
+	if !ok {
+		return value
+	}
+
+	if currency != "" {
+		return fmt.Sprintf("%s%s", currency, parsed)
+	}
+	return parsed
+}
+
+// normalizeCustomFieldValue applies type-aware normalization to a single
+// custom-field value. Only monetary string values are touched; everything
+// else (numbers, bools, non-monetary types, nil) passes through unchanged.
+func normalizeCustomFieldValue(dataType string, value interface{}) interface{} {
+	if dataType != "monetary" {
+		return value
+	}
+	s, ok := value.(string)
+	if !ok {
+		return value
+	}
+	return normalizeMonetary(s)
+}
+
+var (
+	currencyCodePrefixRe = regexp.MustCompile(`^([A-Za-z]{3})`)
+	currencyCodeSuffixRe = regexp.MustCompile(`([A-Za-z]{3})$`)
+	numericCharsRe       = regexp.MustCompile(`^[+\-]?[0-9.,\s]+$`)
+)
+
+var currencySymbolToCode = map[rune]string{
+	'$': "USD",
+	'€': "EUR",
+	'£': "GBP",
+	'¥': "JPY",
+	'₹': "INR",
+	'₩': "KRW",
+	'₽': "RUB",
+}
+
+// splitCurrencyAndNumber pulls a 3-letter ISO-style code or recognized
+// symbol off the start or end of s and returns (uppercase code, numeric
+// body). Returns ("", "") if s contains nothing that looks numeric.
+func splitCurrencyAndNumber(s string) (string, string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+
+	runes := []rune(s)
+
+	// Symbol prefix, e.g. "$1,053.52".
+	if code, ok := currencySymbolToCode[runes[0]]; ok {
+		return code, strings.TrimSpace(string(runes[1:]))
+	}
+	// Symbol suffix, e.g. "1.053,52€".
+	if code, ok := currencySymbolToCode[runes[len(runes)-1]]; ok {
+		return code, strings.TrimSpace(string(runes[:len(runes)-1]))
+	}
+
+	// 3-letter code prefix, e.g. "USD1,053.52" or "USD 1,053.52".
+	if m := currencyCodePrefixRe.FindString(s); m != "" {
+		rest := strings.TrimSpace(s[len(m):])
+		if rest != "" && looksNumeric(rest) {
+			return strings.ToUpper(m), rest
+		}
+	}
+	// 3-letter code suffix, e.g. "1053.52 USD".
+	if m := currencyCodeSuffixRe.FindString(s); m != "" {
+		rest := strings.TrimSpace(s[:len(s)-len(m)])
+		if rest != "" && looksNumeric(rest) {
+			return strings.ToUpper(m), rest
+		}
+	}
+
+	if looksNumeric(s) {
+		return "", s
+	}
+	return "", ""
+}
+
+func looksNumeric(s string) bool {
+	return numericCharsRe.MatchString(strings.TrimSpace(s))
+}
+
+// parseAmount turns a numeric string (no currency code) into "N.NN".
+// Returns ("", false) if the input cannot be confidently parsed.
+func parseAmount(s string) (string, bool) {
+	s = strings.ReplaceAll(strings.TrimSpace(s), " ", "")
+	if s == "" {
+		return "", false
+	}
+
+	sign := ""
+	switch s[0] {
+	case '-':
+		sign = "-"
+		s = s[1:]
+	case '+':
+		s = s[1:]
+	}
+	if s == "" {
+		return "", false
+	}
+
+	hasComma := strings.Contains(s, ",")
+	hasDot := strings.Contains(s, ".")
+
+	var intPart, fracPart string
+	var ok bool
+
+	switch {
+	case hasComma && hasDot:
+		intPart, fracPart, ok = parseBothSeparators(s)
+	case hasComma:
+		intPart, fracPart, ok = parseSingleSeparator(s, ',')
+	case hasDot:
+		intPart, fracPart, ok = parseSingleSeparator(s, '.')
+	default:
+		intPart, fracPart, ok = s, "", isDigits(s)
+	}
+	if !ok {
+		return "", false
+	}
+
+	// Pad/truncate fractional part to exactly two digits. Truncation rather
+	// than rounding keeps behavior deterministic; LLMs rarely emit extra
+	// precision intentionally.
+	switch {
+	case len(fracPart) == 0:
+		fracPart = "00"
+	case len(fracPart) == 1:
+		fracPart = fracPart + "0"
+	case len(fracPart) > 2:
+		fracPart = fracPart[:2]
+	}
+
+	intPart = strings.TrimLeft(intPart, "0")
+	if intPart == "" {
+		intPart = "0"
+	}
+
+	return sign + intPart + "." + fracPart, true
+}
+
+func parseBothSeparators(s string) (intPart, fracPart string, ok bool) {
+	lastComma := strings.LastIndex(s, ",")
+	lastDot := strings.LastIndex(s, ".")
+	var decimalSep, thousandsSep string
+	if lastComma > lastDot {
+		decimalSep, thousandsSep = ",", "."
+	} else {
+		decimalSep, thousandsSep = ".", ","
+	}
+	stripped := strings.ReplaceAll(s, thousandsSep, "")
+	parts := strings.Split(stripped, decimalSep)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	if !isDigits(parts[0]) || !isDigits(parts[1]) {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func parseSingleSeparator(s string, sep rune) (intPart, fracPart string, ok bool) {
+	parts := strings.Split(s, string(sep))
+
+	// Multiple occurrences => all thousands separators.
+	if len(parts) > 2 {
+		if len(parts[0]) < 1 || len(parts[0]) > 3 || !isDigits(parts[0]) {
+			return "", "", false
+		}
+		for _, p := range parts[1:] {
+			if len(p) != 3 || !isDigits(p) {
+				return "", "", false
+			}
+		}
+		return strings.Join(parts, ""), "", true
+	}
+
+	// Exactly one occurrence. The classic thousands-grouping pattern is
+	// exactly 3 digits on the right AND 1-3 digits on the left (e.g. "1,053"
+	// or "1.053"). Anything else is a decimal — including 3-digit-right with
+	// a 4+ digit left (e.g. "1053.525" can only be a decimal, since
+	// thousands groups beyond the leftmost are exactly 3 digits). Excess
+	// decimal precision is truncated by the caller to two digits.
+	left, right := parts[0], parts[1]
+	if !isDigits(left) || !isDigits(right) {
+		return "", "", false
+	}
+
+	if len(right) == 3 && len(left) >= 1 && len(left) <= 3 {
+		return left + right, "", true
+	}
+	return left, right, true
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/normalize_monetary_test.go
+++ b/normalize_monetary_test.go
@@ -1,0 +1,116 @@
+package main
+
+import "testing"
+
+func TestNormalizeMonetary(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		// Real failing values from the issue — these are the values
+		// paperless-ngx's monetary validator rejected with HTTP 400.
+		{"failing_usd_us_thousands_1", "USD1,053.52", "USD1053.52"},
+		{"failing_usd_us_thousands_2", "USD1,013.54", "USD1013.54"},
+
+		// Already-canonical values from working documents must pass through.
+		{"canonical_usd_large", "USD440000.00", "USD440000.00"},
+		{"canonical_no_currency", "1053.52", "1053.52"},
+		{"canonical_zero", "0.00", "0.00"},
+
+		// US: comma-thousands, dot-decimal.
+		{"us_thousands_no_currency", "1,053.52", "1053.52"},
+		{"us_multiple_thousands", "1,053,000.50", "1053000.50"},
+		{"us_dollar_symbol", "$1,053.52", "USD1053.52"},
+
+		// EU: dot-thousands, comma-decimal.
+		{"eu_with_currency_code", "EUR1.053,52", "EUR1053.52"},
+		{"eu_no_currency", "1.053,52", "1053.52"},
+		{"eu_euro_symbol", "€1.053,52", "EUR1053.52"},
+		{"eu_multiple_thousands", "1.053.000,50", "1053000.50"},
+
+		// Single separator, no thousands grouping.
+		{"eu_comma_decimal_only", "1053,52", "1053.52"},
+		{"us_thousands_no_decimal", "1,053", "1053.00"},
+		{"eu_thousands_no_decimal", "1.053", "1053.00"},
+
+		// Integer / partial-decimal handling — pad to exactly two decimals,
+		// truncate excess precision deterministically.
+		{"integer_pads", "1053", "1053.00"},
+		{"one_decimal_pads", "1053.5", "1053.50"},
+		{"three_decimals_truncate", "1053.525", "1053.52"},
+		{"four_decimals_truncate", "1053.5299", "1053.52"},
+
+		// Currency-code variants.
+		{"code_prefix_lowercase", "usd1053.52", "USD1053.52"},
+		{"code_prefix_with_space", "USD 1,053.52", "USD1053.52"},
+		{"code_suffix_with_space", "1053.52 USD", "USD1053.52"},
+
+		// Signs.
+		{"negative_us", "-1,053.52", "-1053.52"},
+		{"explicit_positive", "+1053.52", "1053.52"},
+
+		// Leading-zero cleanup.
+		{"leading_zeros", "0001053.52", "1053.52"},
+
+		// Whitespace-only handling.
+		{"whitespace_padding", "  USD1,053.52  ", "USD1053.52"},
+
+		// Sub-unit values (the integer side is zero).
+		{"sub_unit", "0.05", "0.05"},
+		{"sub_unit_eu", "0,05", "0.05"},
+
+		// Passthrough on inputs we cannot confidently parse — better to
+		// surface the bad value via paperless-ngx's validator than to
+		// guess and silently corrupt it.
+		{"empty", "", ""},
+		{"garbage_passthrough", "abc", "abc"},
+
+		// High-precision decimals: paperless monetary is two-decimal, so
+		// excess precision truncates rather than passes through (a stuck
+		// document is worse than a small precision loss).
+		{"four_digits_after_separator", "1.5299", "1.52"},
+		{"non_thousands_group_truncates", "12,3456", "12.34"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeMonetary(tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeMonetary(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCustomFieldValue(t *testing.T) {
+	cases := []struct {
+		name     string
+		dataType string
+		in       interface{}
+		want     interface{}
+	}{
+		{"monetary_string_normalized", "monetary", "USD1,053.52", "USD1053.52"},
+		{"monetary_already_canonical", "monetary", "USD440000.00", "USD440000.00"},
+
+		// Non-monetary data types must pass through byte-for-byte even if
+		// the value happens to look like a monetary string.
+		{"string_passes_through", "string", "USD1,053.52", "USD1,053.52"},
+		{"date_passes_through", "date", "2026-02-29", "2026-02-29"},
+		{"integer_passes_through", "integer", "1,053", "1,053"},
+
+		// Non-string monetary values (numbers, nil) must pass through —
+		// only string normalization is in scope.
+		{"monetary_number_passes_through", "monetary", 1053.52, 1053.52},
+		{"monetary_int_passes_through", "monetary", 1053, 1053},
+		{"monetary_nil_passes_through", "monetary", nil, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeCustomFieldValue(tc.dataType, tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeCustomFieldValue(%q, %#v) = %#v, want %#v",
+					tc.dataType, tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/paperless.go
+++ b/paperless.go
@@ -471,6 +471,26 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 		availableDocumentTypes[dt.Name] = dt.ID
 	}
 
+	// Build a field-id -> data_type map once per call, lazily — only fetch
+	// when at least one document has suggested custom fields, so users who
+	// don't use the feature pay nothing. Used to normalize monetary values
+	// at the API boundary so paperless-ngx's validator accepts them
+	// (see normalize_monetary.go).
+	var customFieldTypes map[int]string
+	for _, d := range documents {
+		if len(d.SuggestedCustomFields) > 0 {
+			allFields, err := client.GetCustomFields(ctx)
+			if err != nil {
+				return fmt.Errorf("error fetching custom fields for normalization: %w", err)
+			}
+			customFieldTypes = make(map[int]string, len(allFields))
+			for _, f := range allFields {
+				customFieldTypes[f.ID] = f.DataType
+			}
+			break
+		}
+	}
+
 	for _, document := range documents {
 		documentID := document.ID
 		originalDoc := document.OriginalDocument
@@ -601,7 +621,8 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 			case "replace":
 				finalCustomFields = []CustomFieldResponse{}
 				for _, sf := range document.SuggestedCustomFields {
-					finalCustomFields = append(finalCustomFields, CustomFieldResponse{Field: sf.ID, Value: sf.Value})
+					value := normalizeCustomFieldValue(customFieldTypes[sf.ID], sf.Value)
+					finalCustomFields = append(finalCustomFields, CustomFieldResponse{Field: sf.ID, Value: value})
 				}
 			case "update":
 				existingFieldsMap := make(map[int]*CustomFieldResponse)
@@ -609,10 +630,11 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 					existingFieldsMap[finalCustomFields[i].Field] = &finalCustomFields[i]
 				}
 				for _, sf := range document.SuggestedCustomFields {
+					value := normalizeCustomFieldValue(customFieldTypes[sf.ID], sf.Value)
 					if ef, ok := existingFieldsMap[sf.ID]; ok {
-						ef.Value = sf.Value
+						ef.Value = value
 					} else {
-						finalCustomFields = append(finalCustomFields, CustomFieldResponse{Field: sf.ID, Value: sf.Value})
+						finalCustomFields = append(finalCustomFields, CustomFieldResponse{Field: sf.ID, Value: value})
 					}
 				}
 			case "append":
@@ -622,7 +644,8 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 				}
 				for _, sf := range document.SuggestedCustomFields {
 					if _, exists := existingFieldsMap[sf.ID]; !exists {
-						finalCustomFields = append(finalCustomFields, CustomFieldResponse{Field: sf.ID, Value: sf.Value})
+						value := normalizeCustomFieldValue(customFieldTypes[sf.ID], sf.Value)
+						finalCustomFields = append(finalCustomFields, CustomFieldResponse{Field: sf.ID, Value: value})
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- Normalizes monetary custom-field values at the API boundary so paperless-ngx's validator accepts them, eliminating the most common cause of the AUTO_TAG retry loop on 400s.
- Disambiguates US (`1,053.52`) vs EU (`1.053,52`) thousands/decimal separators and emits Paperless-canonical form: optional 3-letter currency code + plain number + exactly two decimals, no thousands separator (e.g. `USD1053.52`).
- Touches only `data_type == "monetary"` string values; every other custom-field value passes through byte-for-byte.

## Why

The LLM frequently produces values like `USD1,053.52`, which paperless-ngx's `monetary` validator rejects. The PATCH to `/api/documents/{id}/` returns 400, the document never clears the AUTO_TAG queue, and `background.go`'s exponential backoff climbs from 10s up to 1h and then loops the same poison document at the 1h cap forever (looks like a hang; it's a retry loop).

Naive comma↔dot replacement fixes EU and breaks US, so the helper disambiguates by separator position/grouping rather than swapping characters.

## Implementation

- New `normalize_monetary.go`: `normalizeMonetary` + `normalizeCustomFieldValue` wrapper.
- `paperless.go:UpdateDocuments` builds a `field_id → data_type` map once per call (lazily — only when at least one document has suggested custom fields, so users not on this feature pay nothing), then normalizes at all three write modes: `replace`, `update`, `append`.

## Out of scope (deliberate)

- 128-char text-field overflow — separate problem, fixable only Paperless-side by migrating to a `long text` field (immutable `data_type`).
- "Skip the bad field rather than failing the whole update" — broader generalization, overlaps with the loop-defense being discussed in #975. Worth a separate PR.
- Date-format normalization (e.g. leap-year `2026-02-29`) — same class of bug, separate fix.

## Test plan

- [x] `go test ./...` — both packages pass
- [x] `TestNormalizeMonetary` — 32 subtests covering: US/EU formats, currency code/symbol variants, integer/single-decimal padding, three-/four-decimal truncation, negative + explicit-positive, leading zeros, whitespace padding, sub-unit values, empty input, garbage passthrough, non-thousands-group truncation
- [x] `gofmt` clean
- [ ] Manual: rerun an AUTO_TAG cycle on a previously-poisoned monetary document and confirm it clears (best done in your environment)

Refs #894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom field values containing monetary amounts now automatically normalize to a consistent standard format when documents are synchronized with Paperless-ngx, supporting various currency codes, symbols, and diverse international number formatting conventions.

* **Tests**
  * Added comprehensive test coverage for monetary value normalization, validating proper handling of multiple currency formats and number conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/icereed/paperless-gpt/pull/978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->