### PR TITLE
feat: add OLLAMA_THINK env var to control Ollama reasoning mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -992,6 +992,16 @@ func createLLM() (llms.Model, error) {
 				log.Warnf("Invalid OLLAMA_CONTEXT_LENGTH value: %v, ignoring", err)
 			}
 		}
+		if thinkStr := os.Getenv("OLLAMA_THINK"); thinkStr != "" {
+			// Allow disabling Ollama reasoning mode for tasks where format
+			// compliance matters more than chain-of-thought (closed-list
+			// classification, strict JSON). Unset = upstream default behavior.
+			if parsed, err := strconv.ParseBool(thinkStr); err == nil {
+				opts = append(opts, ollama.WithThink(parsed))
+			} else {
+				log.Warnf("Invalid OLLAMA_THINK value: %v, ignoring (must be true/false)", err)
+			}
+		}
 		llm, err := ollama.New(opts...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Adds an `OLLAMA_THINK` environment variable that wires through to langchaingo's `ollama.WithThink()` option in the Ollama LLM provider case of `createLLM()`.

- Unset (default): behavior unchanged — the model's own default applies.
- `OLLAMA_THINK=false`: disables reasoning mode.
- `OLLAMA_THINK=true`: explicitly enables it.

Pattern mirrors the existing `GOOGLEAI_THINKING_BUDGET` handling in the same `createLLM()` function (googleai case): read env var, parse, append option. No new dependency — `langchaingo v0.1.14` (current `go.mod` pin) already exposes `ollama.WithThink`.

## Motivation

Newer Ollama models in the Gemma 4 and Qwen 3 families ship with reasoning mode enabled by default. For paperless-gpt's task profile this is actively harmful:

- **Closed-list correspondent extraction** (the entire premise of `correspondent_prompt.tmpl` — pick from `{{.AvailableCorrespondents}}` or return `Unknown`).
- **3-line classification output** (tag prompt — strict format).
- **Any structured/short response** where chain-of-thought is irrelevant.

Without this option, thinking-mode models route their answer into a separate reasoning channel and leave `content` empty until reasoning completes. At normal token budgets they never finish and emit the actual answer, so paperless-gpt sees blank responses, falls back to defaults, and correspondent extraction degrades.

## Testing

Tested locally with `gemma4:12b` against a 105-entry closed correspondent list. Without `OLLAMA_THINK=false` the model returns empty `content`; with it set, correspondent names parse cleanly. On an 8-document test set, gemma4:12b reached 7/8 exact match (vs 6/8 for the previously-validated qwen2.5:14b-instruct on the same set), including a case where qwen2.5 invented a plausible-but-wrong correspondent that gemma4 correctly returned as `Unknown`.

## Test plan

- [x] Builds cleanly with existing `go.mod` (langchaingo v0.1.14)
- [x] Backward compatible — `OLLAMA_THINK` unset = no behavior change for existing users
- [x] Verified end-to-end against a real Paperless instance with gemma4:12b
- [ ] Reviewer to confirm the env-var naming + log-warning wording match project conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama users can now configure extended thinking behavior through environment variable settings. Invalid configurations are safely handled with warning logs while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->