### PR TITLE
Reduce document polling load

### DIFF
--- a/web-app/src/DocumentProcessor.tsx
+++ b/web-app/src/DocumentProcessor.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import "react-tag-autocomplete/example/src/styles.css"; // Ensure styles are loaded
 import DocumentsToProcess from "./components/DocumentsToProcess";
 import NoDocuments from "./components/NoDocuments";
@@ -74,6 +74,7 @@ const DocumentProcessor: React.FC = () => {
   const [generateCreatedDate, setGenerateCreatedDate] = useState(true);
   const [generateCustomFields, setGenerateCustomFields] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const pollingDocumentsRef = useRef(false);
 
   // Custom hook to fetch initial data
   const fetchInitialData = useCallback(async () => {
@@ -263,6 +264,11 @@ const DocumentProcessor: React.FC = () => {
   useEffect(() => {
     if (documents.length === 0) {
       const interval = setInterval(async () => {
+        if (pollingDocumentsRef.current) {
+          return;
+        }
+
+        pollingDocumentsRef.current = true;
         setError(null);
         try {
           const { data } = await axios.get<Document[]>("./api/documents");
@@ -270,8 +276,10 @@ const DocumentProcessor: React.FC = () => {
         } catch (err) {
           console.error("Error reloading documents:", err);
           setError("Failed to reload documents.");
+        } finally {
+          pollingDocumentsRef.current = false;
         }
-      }, 500);
+      }, 30000);
       return () => clearInterval(interval);
     }
   }, [documents]);

--- a/web-app/src/DocumentProcessor.tsx
+++ b/web-app/src/DocumentProcessor.tsx
@@ -279,7 +279,7 @@ const DocumentProcessor: React.FC = () => {
         } finally {
           pollingDocumentsRef.current = false;
         }
-      }, 30000);
+      }, 5000);
       return () => clearInterval(interval);
     }
   }, [documents]);


### PR DESCRIPTION
## Summary
- Increased empty document polling interval from 500ms to 5 seconds
- Skip automatic polling when the previous document request is still in flight

## Context
When no documents have been loaded yet, `DocumentProcessor` currently polls `/api/documents` every 500ms. If Paperless is slow to respond, multiple requests can overlap and keep adding load. 

In my case, one call to `/api/documents` results into a lot of calls to Paperless. Repeating that every 500ms made Paperless very slow/unresponsive:
```
2026-06-20T11:07:14.100327486Z [paperless_gpt] time="2026-06-20T11:07:14Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?name__iexact=paperless-gpt"
2026-06-20T11:07:14.486183847Z [paperless_gpt] time="2026-06-20T11:07:14Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/documents/?tags__name__iexact=paperless-gpt&page_size=25"
2026-06-20T11:07:15.270431110Z [paperless_gpt] time="2026-06-20T11:07:15Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/"
2026-06-20T11:07:16.112416359Z [paperless_gpt] time="2026-06-20T11:07:16Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=2"
2026-06-20T11:07:17.225211714Z [paperless_gpt] time="2026-06-20T11:07:17Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=3"
2026-06-20T11:07:18.477045064Z [paperless_gpt] time="2026-06-20T11:07:18Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=4"
2026-06-20T11:07:19.070887018Z [paperless_gpt] time="2026-06-20T11:07:19Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=5"
2026-06-20T11:07:19.559718317Z [paperless_gpt] time="2026-06-20T11:07:19Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=6"
2026-06-20T11:07:20.556874429Z [paperless_gpt] time="2026-06-20T11:07:20Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=7"
2026-06-20T11:07:21.340710704Z [paperless_gpt] time="2026-06-20T11:07:21Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=8"
2026-06-20T11:07:21.874764210Z [paperless_gpt] time="2026-06-20T11:07:21Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=9"
2026-06-20T11:07:22.405278601Z [paperless_gpt] time="2026-06-20T11:07:22Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/tags/?page=10"
2026-06-20T11:07:22.711051282Z [paperless_gpt] time="2026-06-20T11:07:22Z" level=debug msg="Making HTTP request" method=GET url="http://paperless-webserver:8000/api/correspondents/?page_size=9999"
2026-06-20T11:07:22.854520690Z [paperless_gpt] [GIN] 2026/06/20 - 11:07:22 | 200 |  8.755715061s |      10.10.0.59 | GET      "/api/documents"
```

This change keeps the existing polling behavior, but makes it less aggressive and prevents overlapping document fetches.

## Validation
- npm run build
- git diff --check

## AI disclaimer
Issue was found manually. Codex was used to validate assumptions and create the fix. Change was reviewed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized document polling for improved reliability and performance while reducing system resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->