### PR TITLE
fix(e2e): make Mistral OCR phrase assertion robust to model drift

### DIFF
--- a/web-app/e2e/mistral-ocr-processing.spec.ts
+++ b/web-app/e2e/mistral-ocr-processing.spec.ts
@@ -202,10 +202,29 @@ test('should process multi-page PDF with Mistral OCR using whole_pdf mode', asyn
   // For a 5-page PDF, we should get substantial text content
   expect(documentContent?.length).toBeGreaterThan(100);
 
-  // Should contain "Musée royal d'Histoire naturelle de Belgique" (with or without period)
-  // OCR may extract with minor variations in punctuation
-  const hasExpectedText = documentContent?.includes("Musée royal d'Histoire naturelle de Belgique") || 
-                          documentContent?.includes("Musée royal d'Histoire naturelle de. Belgique");
+  // Should contain "Musée royal d'Histoire naturelle de Belgique".
+  // In the source document the phrase is split across a line break
+  // ("...d'Histoire" / "naturelle..."), and mistral-ocr-latest is an unpinned
+  // model whose line-break, apostrophe and punctuation rendering changes over
+  // time. Compare on a normalized form (diacritics folded, everything except
+  // letters collapsed to single spaces) so the assertion only fails when the
+  // museum name is genuinely missing from the OCR output.
+  const normalizeForMatch = (s: string) =>
+    s
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/g, '') // strip combining diacritical marks
+      .toLowerCase()
+      .replace(/[^a-z]+/g, ' ')
+      .trim();
+
+  const expectedPhrase = normalizeForMatch("Musée royal d'Histoire naturelle de Belgique");
+  const hasExpectedText = normalizeForMatch(documentContent ?? '').includes(expectedPhrase);
+  if (!hasExpectedText) {
+    console.log('Expected phrase not found in OCR output. Full document content for diagnosis:');
+    console.log('=== OCR CONTENT START ===');
+    console.log(documentContent);
+    console.log('=== OCR CONTENT END ===');
+  }
   expect(hasExpectedText).toBeTruthy();
   
   console.log(`OCR processing successful! Extracted ${documentContent?.length} characters of text.`);


### PR DESCRIPTION
## Problem

Main's E2E job fails since #990 landed — but not because of #990. The failing assertion in `mistral-ocr-processing.spec.ts` expects the exact substring `Musée royal d'Histoire naturelle de Belgique` in the OCR output. In the source PDF that phrase is split across a line break (`...d'Histoire` / `naturelle...`), so the test only passed while `mistral-ocr-latest` (unpinned) happened to join those lines with a plain space. The model was updated since the last green run (2026-03-29) and the rendering changed; OCR itself still works (5852 chars extracted, tag flow completes).

Evidence it's drift, not #990: the same assertion fails identically on unrelated renovate branches, and the diff of #990 leaves the mistral_ocr whole_pdf path functionally untouched (the per-document prompt clone applies to `LLMProvider` only, `sanitize` is env-gated off in CI, and the `test-environment.ts` change was a pure setup/teardown refactor).

## Fix

Compare on a normalized form — NFKD diacritic folding, lowercase, non-letter runs collapsed to single spaces — so line breaks, apostrophe variants, stray punctuation and markdown emphasis no longer matter, while a genuinely missing museum name still fails the test. On mismatch the full OCR content is dumped to the CI log so the next drift is diagnosable without re-running anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved OCR text verification to better handle punctuation, accents, and spacing variations.
  * Added clearer diagnostic output when expected OCR text is missing, making failures easier to troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->