### PR TITLE
fix(ci): skip registry logins on pull_request builds

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -141,12 +141,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
-        if: github.repository == 'icereed/paperless-gpt'
+        # Fork PRs have no secrets, and PR builds never push (`push: false`
+        # below) — logging in would fail with "Username and password required".
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'icereed/paperless-gpt' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -158,7 +161,7 @@ jobs:
           # Set repository names
           DOCKERHUB_REPO="icereed/paperless-gpt"
           GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY}"
-          
+
           # For forks, only use GHCR
           if [[ "${GITHUB_REPOSITORY}" != "icereed/paperless-gpt" ]]; then
             if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then


### PR DESCRIPTION
## Problem

Every fork PR currently fails the `build-amd64` check after ~17s with **"Username and password required"** (see #922, #660, #470, #458). Contributors see a red X they can do nothing about.

Root cause: the Docker Hub login step in `build-amd64` only checks `github.repository == 'icereed/paperless-gpt'` — which is *true* for fork PRs against this repo — but fork PRs have no access to repo secrets, so the login runs with empty credentials and fails.

## Fix

Skip both registry logins on `pull_request` events, exactly like `build-arm64` already does (which is why that job is green on fork PRs). PR builds never push (`push: false`), so no login is needed.

## Impact

Fork PRs immediately get a green `build-amd64` check. No security implications — this removes a credential use, it doesn't add one.

Part 1/3 of the contributor-friendly CI rework (next: secret-free mock-LLM E2E for all PRs, then an environment-approval gate for real-LLM E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker build workflow behavior for pull requests, preventing failed login attempts during fork-based builds.
  * Limited registry login steps to run only when publishing from the main repository, reducing unnecessary workflow errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->