### PR TITLE
fix(ocr): polish the Playground ramp-to-automation and Activity trust surface

### DIFF
--- a/internal/textsanitize/codefence.go
+++ b/internal/textsanitize/codefence.go
@@ -1,0 +1,42 @@
+package textsanitize
+
+import "strings"
+
+// StripCodeFences removes a single Markdown code fence that wraps the entire
+// content — e.g. a vision model returning its OCR output inside a
+// ```markdown … ``` block. Only a fence enclosing the whole text is removed;
+// fenced blocks that are genuinely part of the recognized document (or inline
+// backticks) are left untouched, so the recognized text is never mangled.
+func StripCodeFences(content string) string {
+	trimmed := strings.TrimSpace(content)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+
+	lines := strings.Split(trimmed, "\n")
+
+	// A fence-delimiter line is one whose trimmed text starts with ```.
+	var fenceLines []int
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			fenceLines = append(fenceLines, i)
+		}
+	}
+
+	// Only unwrap when exactly one fence encloses the whole content: an opening
+	// line at the top and a closing line at the very bottom. Anything else is
+	// ambiguous (multiple blocks, no closing fence) and is left as-is.
+	if len(fenceLines) != 2 || fenceLines[0] != 0 || fenceLines[1] != len(lines)-1 {
+		return trimmed
+	}
+
+	// The opening line must carry only an optional language tag (e.g. "markdown"),
+	// never real content that happened to start with backticks.
+	info := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[0]), "```"))
+	if strings.ContainsAny(info, " \t") {
+		return trimmed
+	}
+
+	inner := strings.Join(lines[1:fenceLines[1]], "\n")
+	return strings.TrimSpace(inner)
+}

--- a/internal/textsanitize/codefence_test.go
+++ b/internal/textsanitize/codefence_test.go
@@ -1,0 +1,74 @@
+package textsanitize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStripCodeFences verifies that only a fence wrapping the whole content is
+// removed, while legitimate fences and inline backticks are preserved.
+func TestStripCodeFences(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "No fence",
+			input:    "Plain recognized text.",
+			expected: "Plain recognized text.",
+		},
+		{
+			name:     "Wrapping fence with language tag",
+			input:    "```markdown\nRecognized text\nsecond line\n```",
+			expected: "Recognized text\nsecond line",
+		},
+		{
+			name:     "Wrapping fence without language tag",
+			input:    "```\nRecognized text\n```",
+			expected: "Recognized text",
+		},
+		{
+			name:     "Wrapping fence with surrounding whitespace",
+			input:    "\n\n```markdown\nRecognized text\n```\n\n",
+			expected: "Recognized text",
+		},
+		{
+			name:     "Empty content",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Fence with only opening (no close) left untouched",
+			input:    "```markdown\nRecognized text without a close",
+			expected: "```markdown\nRecognized text without a close",
+		},
+		{
+			name:     "Inline backticks preserved",
+			input:    "```markdown\nUse the `foo` command here\n```",
+			expected: "Use the `foo` command here",
+		},
+		{
+			name:     "Two independent code blocks are not unwrapped",
+			input:    "```python\ncode\n```\ntext\n```js\nmore\n```",
+			expected: "```python\ncode\n```\ntext\n```js\nmore\n```",
+		},
+		{
+			name:     "Opening line with real content is not a fence",
+			input:    "```not a real fence because text follows on same line\nbody\n```",
+			expected: "```not a real fence because text follows on same line\nbody\n```",
+		},
+		{
+			name:     "Empty fenced block",
+			input:    "```\n\n```",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, StripCodeFences(tc.input))
+		})
+	}
+}

--- a/ocr/llm_provider.go
+++ b/ocr/llm_provider.go
@@ -179,6 +179,9 @@ func (p *LLMProvider) ProcessImage(ctx context.Context, imageContent []byte, pag
 	}
 
 	text := textsanitize.StripReasoning(completion.Choices[0].Content)
+	// Some vision models wrap their whole answer in a ```markdown … ``` fence;
+	// strip it so the recognized text isn't polluted with model scaffolding.
+	text = textsanitize.StripCodeFences(text)
 	limitHit := false
 	tokenCount := -1
 

--- a/web-app/src/OCR.tsx
+++ b/web-app/src/OCR.tsx
@@ -328,15 +328,15 @@ VISION_LLM_MODEL=minicpm-v`}
                       </span>
                     </li>
                   </ol>
-                  <p className="mt-5 flex flex-wrap items-center gap-x-1.5 gap-y-1 border-t border-line pt-4 text-sm text-muted">
+                  <p className="mt-5 border-t border-line pt-4 text-sm text-muted">
                     <BoltIcon
-                      className="h-4 w-4 shrink-0 text-faint"
+                      className="mr-1.5 inline-block h-4 w-4 align-text-bottom text-faint"
                       aria-hidden="true"
                     />
-                    Want it hands-off? Tag documents with
+                    Want it hands-off? Tag documents with{" "}
                     <span className="whitespace-nowrap rounded-full bg-primary-tint px-2 py-0.5 text-xs font-medium text-ink">
                       {config.auto_tag}
-                    </span>
+                    </span>{" "}
                     to run OCR automatically — every run lands in the{" "}
                     <Link
                       to="/ocr?tab=activity"

--- a/web-app/src/OCR.tsx
+++ b/web-app/src/OCR.tsx
@@ -1,4 +1,10 @@
-import { StopIcon } from "@heroicons/react/24/outline";
+import {
+  AdjustmentsHorizontalIcon,
+  BoltIcon,
+  DocumentMagnifyingGlassIcon,
+  SparklesIcon,
+  StopIcon,
+} from "@heroicons/react/24/outline";
 import axios from "axios";
 import classNames from "classnames";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -270,6 +276,80 @@ VISION_LLM_MODEL=minicpm-v`}
             onSelect={selectDocument}
             disabled={jobRunning}
           />
+
+          {!selectedDoc && !jobRunning && (
+            <div className="rounded-lg border border-line bg-surface p-6 sm:p-8">
+              <div className="flex items-start gap-4">
+                <div className="hidden shrink-0 rounded-lg bg-primary-tint p-2.5 sm:block">
+                  <DocumentMagnifyingGlassIcon
+                    className="h-6 w-6 text-primary"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="min-w-0">
+                  <h2 className="text-base font-semibold">
+                    Try LLM-based OCR on any document
+                  </h2>
+                  <p className="mt-1.5 max-w-prose text-sm text-muted">
+                    Pick a document above — search by title or content, or paste a
+                    paperless ID or URL — to see the scan beside freshly recognized
+                    text. Tune the options, compare runs, then apply the result
+                    back to paperless-ngx.
+                  </p>
+                  <ol className="mt-4 flex flex-col gap-3 sm:flex-row sm:gap-6">
+                    <li className="flex items-center gap-2 text-sm text-muted">
+                      <DocumentMagnifyingGlassIcon
+                        className="h-4 w-4 shrink-0 text-faint"
+                        aria-hidden="true"
+                      />
+                      <span>
+                        <span className="font-medium text-ink">Pick</span> a
+                        document
+                      </span>
+                    </li>
+                    <li className="flex items-center gap-2 text-sm text-muted">
+                      <AdjustmentsHorizontalIcon
+                        className="h-4 w-4 shrink-0 text-faint"
+                        aria-hidden="true"
+                      />
+                      <span>
+                        <span className="font-medium text-ink">Tune &amp; run</span>{" "}
+                        the OCR
+                      </span>
+                    </li>
+                    <li className="flex items-center gap-2 text-sm text-muted">
+                      <SparklesIcon
+                        className="h-4 w-4 shrink-0 text-faint"
+                        aria-hidden="true"
+                      />
+                      <span>
+                        <span className="font-medium text-ink">Apply</span> or
+                        automate
+                      </span>
+                    </li>
+                  </ol>
+                  <p className="mt-5 flex flex-wrap items-center gap-x-1.5 gap-y-1 border-t border-line pt-4 text-sm text-muted">
+                    <BoltIcon
+                      className="h-4 w-4 shrink-0 text-faint"
+                      aria-hidden="true"
+                    />
+                    Want it hands-off? Tag documents with
+                    <span className="whitespace-nowrap rounded-full bg-primary-tint px-2 py-0.5 text-xs font-medium text-ink">
+                      {config.auto_tag}
+                    </span>
+                    to run OCR automatically — every run lands in the{" "}
+                    <Link
+                      to="/ocr?tab=activity"
+                      className="font-medium text-primary hover:underline"
+                    >
+                      Activity log
+                    </Link>
+                    .
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
 
           {selectedDoc && (
             <RunOptionsPanel

--- a/web-app/src/components/ocr/ActivityTab.tsx
+++ b/web-app/src/components/ocr/ActivityTab.tsx
@@ -2,6 +2,7 @@ import {
   ArrowPathIcon,
   BoltIcon,
   CheckCircleIcon,
+  ChevronDownIcon,
   ExclamationTriangleIcon,
   XCircleIcon,
 } from "@heroicons/react/24/outline";
@@ -34,7 +35,20 @@ const statusMeta: Record<
 const ActivityTab: React.FC<ActivityTabProps> = ({ config }) => {
   const [runs, setRuns] = useState<OCRRun[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Run ids whose full failure detail (error text + untruncated title) is shown.
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const navigate = useNavigate();
+
+  const toggleExpanded = (id: number) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
   // Monotonic id so an older, slower poll can't overwrite a newer snapshot.
   const requestSeq = useRef(0);
 
@@ -129,6 +143,15 @@ const ActivityTab: React.FC<ActivityTabProps> = ({ config }) => {
             const meta = statusMeta[run.status] || statusMeta.completed;
             const Icon = meta.icon;
             const duration = runDuration(run);
+            const isExpanded = expanded.has(run.id);
+            const pdfDetail =
+              (run.pdf_action === "skipped" || run.pdf_action === "failed") &&
+              run.pdf_detail
+                ? run.pdf_detail
+                : null;
+            const errorDetail =
+              run.error && run.status !== "completed" ? run.error : null;
+            const hasDetails = Boolean(errorDetail || pdfDetail);
             return (
               <li
                 key={run.id}
@@ -153,7 +176,12 @@ const ActivityTab: React.FC<ActivityTabProps> = ({ config }) => {
                   {run.trigger === "auto" ? "auto" : "manual"}
                 </span>
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium" title={run.document_title}>
+                  <p
+                    className={classNames(
+                      "text-sm font-medium",
+                      !isExpanded && "truncate"
+                    )}
+                  >
                     {run.document_title || `Document ${run.document_id}`}
                   </p>
                   <p className="truncate text-xs text-muted">
@@ -170,16 +198,44 @@ const ActivityTab: React.FC<ActivityTabProps> = ({ config }) => {
                       Original replaced with searchable PDF
                     </p>
                   )}
-                  {(run.pdf_action === "skipped" || run.pdf_action === "failed") &&
-                    run.pdf_detail && (
-                      <p className="mt-0.5 truncate text-xs text-warn" title={run.pdf_detail}>
-                        PDF {run.pdf_action}: {run.pdf_detail}
-                      </p>
-                    )}
-                  {run.error && run.status !== "completed" && (
-                    <p className="mt-0.5 truncate text-xs text-neg" title={run.error}>
-                      {run.error}
+                  {pdfDetail && (
+                    <p
+                      className={classNames(
+                        "mt-0.5 text-xs text-warn",
+                        isExpanded
+                          ? "whitespace-pre-wrap break-words"
+                          : "truncate"
+                      )}
+                    >
+                      PDF {run.pdf_action}: {pdfDetail}
                     </p>
+                  )}
+                  {errorDetail && (
+                    <p
+                      className={classNames(
+                        "mt-0.5 text-xs text-neg",
+                        isExpanded ? "whitespace-pre-wrap break-words" : "truncate"
+                      )}
+                    >
+                      {errorDetail}
+                    </p>
+                  )}
+                  {hasDetails && (
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(run.id)}
+                      aria-expanded={isExpanded}
+                      className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-muted hover:text-ink"
+                    >
+                      <ChevronDownIcon
+                        className={classNames(
+                          "h-3.5 w-3.5 transition-transform duration-150 ease-out-quart",
+                          isExpanded && "rotate-180"
+                        )}
+                        aria-hidden="true"
+                      />
+                      {isExpanded ? "Hide details" : "Show details"}
+                    </button>
                   )}
                 </div>
                 <Button

--- a/web-app/src/components/ocr/RunOptionsPanel.tsx
+++ b/web-app/src/components/ocr/RunOptionsPanel.tsx
@@ -1,4 +1,8 @@
-import { ChevronDownIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import {
+  BookmarkSquareIcon,
+  ChevronDownIcon,
+  SparklesIcon,
+} from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import React, { useEffect, useState } from "react";
 import Button from "../ui/Button";
@@ -245,13 +249,15 @@ const RunOptionsPanel: React.FC<RunOptionsPanelProps> = ({
 
         <div className="flex items-center gap-2">
           <Button
-            variant="ghost"
-            size="sm"
+            variant="secondary"
             onClick={handleSaveDefaults}
             loading={savingDefaults}
             disabled={running}
-            title="Auto-OCR and future runs use these options"
+            title="Make these options the standard for Auto-OCR and future runs"
           >
+            {!savingDefaults && (
+              <BookmarkSquareIcon className="h-4 w-4" aria-hidden="true" />
+            )}
             Save as defaults
           </Button>
           <Button variant="primary" onClick={onStart} disabled={!canStart} loading={running}>


### PR DESCRIPTION
## Why

A pre-release critique (dual-agent, run against the live deployment) landed the OCR redesign at **32/40 with a clean build** — no console errors, no genuine detector defects. The friction that remained clustered precisely on the product's north star: *the UI as a ramp to hands-off Auto-OCR*. This PR closes the two P1s and two P2s from that critique.

## Changes

- **[P1] "Save as defaults" now reads as a control.** It's the manual→auto promotion action, but it rendered as a muted ghost button beside the primary *Run OCR* and looked like plain text. Promoted to a bordered `secondary` button with a bookmark icon — the second-most-important action on the panel.
- **[P1] The Playground teaches on first open.** It previously opened to a bare search field over an empty canvas — the worst first impression of the four surfaces, and the one meant to build trust. Added a teaching empty state (*pick → tune & run → apply/automate*) with a pointer to Auto-OCR tagging and the Activity log, mirroring the Home empty state.
- **[P2] Model scaffolding no longer leaks into recognized text.** Vision models sometimes wrap their whole answer in a ` ```markdown … ``` ` fence, which surfaced verbatim in the result and got applied to paperless-ngx. A new `textsanitize.StripCodeFences` removes a single whole-content fence at the source — conservatively, so inline backticks and genuine multi-block content are untouched (10 test cases).
- **[P2] Activity failures are diagnosable.** The full error and long document title lived only in a `title` attribute — unreachable for touch and screen-reader users. Added a per-row *Show details* disclosure that un-truncates the title and reveals the full error / PDF detail.

## Testing

- `go test ./internal/textsanitize/` — 22 pass (incl. the new fence cases)
- `go build ./...` — clean; full binary builds
- `npm run lint` — clean on all touched files
- `npm run build` — TypeScript compiles, Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qy47KUp6J7Z7R4NnUqNBw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OCR playground empty-state guide for picking a document, running OCR, and applying/automating results (with a link to Activity).
  * Enhanced the Activity tab with per-run expand/collapse to reveal error and PDF-related details.
  * Updated “Save as defaults” with improved styling and a clearer visual state indicator.
* **Bug Fixes**
  * Prevented OCR output from including surrounding Markdown code fences returned by the model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->