### PR TITLE
fix(llm): support streaming-compatible OpenAI gateways

### DIFF
--- a/app_http_handlers.go
+++ b/app_http_handlers.go
@@ -1069,7 +1069,7 @@ func (app *App) analyzeDocumentsHandler(c *gin.Context) {
 	finalPrompt := promptBuffer.String()
 
 	// Call LLM with the custom prompt and document contexts
-	llmResponse, err := app.LLM.Call(ctx, finalPrompt)
+	llmResponse, err := app.LLM.Call(ctx, finalPrompt, configuredLLMCallOptions()...)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error calling LLM"})
 		log.Errorf("Error calling LLM: %v", err)

--- a/app_llm.go
+++ b/app_llm.go
@@ -19,6 +19,16 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
+func configuredLLMCallOptions() []llms.CallOption {
+	options := []llms.CallOption{llms.WithModel(llmModel)}
+	if strings.EqualFold(llmProvider, "openai") {
+		// Some compatible gateways stream unless stream=false is explicit. The
+		// LangChain client omits false, so enable its SSE parser deliberately.
+		options = append(options, llms.WithStreamingFunc(func(context.Context, []byte) error { return nil }))
+	}
+	return options
+}
+
 // getSuggestedCorrespondent generates a suggested correspondent for a document using the LLM
 func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, suggestedTitle string, availableCorrespondents []string, correspondentBlackList []string) (string, error) {
 	likelyLanguage := getLikelyLanguage()
@@ -65,7 +75,7 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 			},
 			Role: llms.ChatMessageTypeHuman,
 		},
-	})
+	}, configuredLLMCallOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
@@ -135,7 +145,7 @@ func (app *App) getSuggestedTags(
 			},
 			Role: llms.ChatMessageTypeHuman,
 		},
-	})
+	}, configuredLLMCallOptions()...)
 	if err != nil {
 		logger.Errorf("Error getting response from LLM: %v", err)
 		return nil, fmt.Errorf("error getting response from LLM: %v", err)
@@ -243,7 +253,7 @@ func (app *App) getSuggestedDocumentType(
 			},
 			Role: llms.ChatMessageTypeHuman,
 		},
-	})
+	}, configuredLLMCallOptions()...)
 	if err != nil {
 		logger.Errorf("Error getting response from LLM: %v", err)
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
@@ -313,7 +323,7 @@ func (app *App) getSuggestedTitle(ctx context.Context, content string, originalT
 			},
 			Role: llms.ChatMessageTypeHuman,
 		},
-	})
+	}, configuredLLMCallOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
@@ -369,13 +379,14 @@ func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, log
 			},
 			Role: llms.ChatMessageTypeHuman,
 		},
-	})
+	}, configuredLLMCallOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("error getting response from LLM: %v", err)
 	}
 	result := textsanitize.StripReasoning(completion.Choices[0].Content)
 	return strings.TrimSpace(strings.Trim(result, "\"")), nil
 }
+
 var xmlAttrEscaper = strings.NewReplacer(
 	"&", "&amp;",
 	`"`, "&quot;",
@@ -392,6 +403,7 @@ var xmlTextEscaper = strings.NewReplacer(
 
 func escapeXMLAttr(s string) string { return xmlAttrEscaper.Replace(s) }
 func escapeXMLText(s string) string { return xmlTextEscaper.Replace(s) }
+
 // getSuggestedCustomFields generates suggested custom fields for a document using the LLM
 func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, selectedFieldIDs []int, logger *logrus.Entry) ([]CustomFieldSuggestion, error) {
 	// Fetch all available custom fields
@@ -470,7 +482,7 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 				llms.TextContent{Text: prompt},
 			},
 		},
-	})
+	}, configuredLLMCallOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("error getting response from LLM for custom fields: %v", err)
 	}

--- a/app_llm_test.go
+++ b/app_llm_test.go
@@ -17,9 +17,11 @@ import (
 
 // Mock LLM for testing
 type mockLLM struct {
-	lastPrompt string
-	Response   string
-	Error      error
+	lastPrompt    string
+	lastModel     string
+	lastStreaming bool
+	Response      string
+	Error         error
 }
 
 func (m *mockLLM) CreateEmbedding(_ context.Context, texts []string) ([][]float32, error) {
@@ -38,6 +40,13 @@ func (m *mockLLM) Call(ctx context.Context, prompt string, options ...llms.CallO
 }
 
 func (m *mockLLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	opts := llms.CallOptions{}
+	for _, option := range options {
+		option(&opts)
+	}
+	m.lastModel = opts.Model
+	m.lastStreaming = opts.StreamingFunc != nil
+
 	if len(messages) > 0 && len(messages[0].Parts) > 0 {
 		if textContent, ok := messages[0].Parts[0].(llms.TextContent); ok {
 			m.lastPrompt = textContent.Text
@@ -60,6 +69,25 @@ func (m *mockLLM) GenerateContent(ctx context.Context, messages []llms.MessageCo
 			},
 		},
 	}, nil
+}
+
+func TestTitleGenerationPassesConfiguredModel(t *testing.T) {
+	previousTemplate := titleTemplate
+	titleTemplate = template.Must(template.New("title").Parse(testTitleTemplate))
+	t.Cleanup(func() { titleTemplate = previousTemplate })
+	model := &mockLLM{Response: "Suggested title"}
+	app := &App{LLM: model}
+	previousModel := llmModel
+	llmModel = "frontier"
+	t.Cleanup(func() { llmModel = previousModel })
+	previousProvider := llmProvider
+	llmProvider = "openai"
+	t.Cleanup(func() { llmProvider = previousProvider })
+
+	_, err := app.getSuggestedTitle(context.Background(), "Document content", "Original title", logrus.WithField("test", "model"))
+	require.NoError(t, err)
+	assert.Equal(t, "frontier", model.lastModel)
+	assert.True(t, model.lastStreaming)
 }
 
 // Mock templates for testing


### PR DESCRIPTION
## Summary

Fix compatibility with OpenAI-compatible gateways that:

- Require the model to be explicitly included in each request.
- Return SSE streaming responses when the `stream` field is omitted.

Paperless-GPT previously failed to decode these responses with:

```invalid character 'd' looking for beginning of value```

The d is the first character of an SSE 'data:' frame


## Root Cause
Paperless-GPT configures the model when constructing the LangChainGo OpenAI client, but LangChainGo v0.1.14 builds individual chat requests using the per-call model option.
Because Paperless-GPT did not provide that option, affected requests contained an empty model:
```
{
  "model": ""
}
```
LangChainGo also omits stream when it is false. Some OpenAI-compatible gateways interpret the missing field as streaming enabled and respond with text/event-stream.
LangChainGo then attempts to decode the SSE response as a regular JSON object, resulting in the decoder error above.

## Changes
- Explicitly pass the configured LLM_MODEL to metadata-generation calls.
- Apply the same model option to ad-hoc analysis.
- For the OpenAI provider, enable LangChainGo's streaming response parser with a no-op streaming callback.
- Add regression coverage confirming that the configured model and streaming callback are passed to generation calls.
This applies only to the OpenAI/OpenAI-compatible provider. Other providers retain their existing behavior.

## Verification
Tested against an OpenAI-compatible gateway that defaults to SSE when stream is omitted.
Before this change:
```
All documents failed
error getting response from LLM:
invalid character 'd' looking for beginning of value
```
After this change:

- A title-only suggestion job completed successfully.
- Result: 1 ok, 0 failed.
- The configured model was correctly selected.
- No document changes were applied during verification.
The production container image also compiled successfully.

## Notes
The compatibility issue is caused by a combination of:
1. LangChainGo v0.1.14 not propagating the client model into the request unless supplied as a call option.
2. stream: false being omitted because of `omitempty`.
3. Some compatible gateways defaulting to SSE when `stream` is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Applied the configured AI model consistently across document analysis and generated metadata, including titles, tags, dates, and custom fields.
  * Enabled streaming responses for supported OpenAI-powered workflows, improving responsiveness during AI processing.
  * Updated AI processing behavior to honor provider and model settings more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->