### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,19 +171,24 @@ services:
       LLM_MODEL: "gpt-4o"
       OPENAI_API_KEY: "your_openai_api_key"
 
-      # Option 2: Mistral
+      # Option 2: Atlas Cloud
+      # LLM_PROVIDER: "atlas"
+      # LLM_MODEL: "qwen/qwen3.8-max"
+      # ATLAS_API_KEY: "your_atlas_api_key"
+
+      # Option 3: Mistral
       # LLM_PROVIDER: "mistral"
       # LLM_MODEL: "mistral-large-latest"
       # MISTRAL_API_KEY: "your_mistral_api_key"
 
-      # Option 3: Azure OpenAI
+      # Option 4: Azure OpenAI
       # LLM_PROVIDER: "openai"
       # LLM_MODEL: "your-deployment-name"
       # OPENAI_API_KEY: "your_azure_api_key"
       # OPENAI_API_TYPE: "azure"
       # OPENAI_BASE_URL: "https://your-resource.openai.azure.com"
 
-      # Option 4: Ollama (Local)
+      # Option 5: Ollama (Local)
       # LLM_PROVIDER: "ollama"
       # LLM_MODEL: "qwen3:8b"
       # OLLAMA_HOST: "http://host.docker.internal:11434"
@@ -191,7 +196,7 @@ services:
       # OLLAMA_HEADERS: "Authorization=Bearer mytoken" # Optional headers for reverse-proxy auth
       # TOKEN_LIMIT: 1000 # Recommended for smaller models
 
-      # Option 5: Anthropic/Claude
+      # Option 6: Anthropic/Claude
       # LLM_PROVIDER: "anthropic"
       # LLM_MODEL: "claude-sonnet-4-5"
       # ANTHROPIC_API_KEY: "your_anthropic_api_key"
@@ -202,7 +207,7 @@ services:
       # OCR Configuration - Choose one:
       # Option 1: LLM-based OCR
       OCR_PROVIDER: "llm" # Default OCR provider
-      VISION_LLM_PROVIDER: "ollama" # openai, ollama, mistral, or anthropic
+      VISION_LLM_PROVIDER: "ollama" # openai, atlas, ollama, mistral, or anthropic
       VISION_LLM_MODEL: "minicpm-v" # minicpm-v (ollama) or gpt-4o (openai) or claude-sonnet-4-5 (anthropic/claude)
       OLLAMA_HOST: "http://host.docker.internal:11434" # If using Ollama
 
@@ -566,9 +571,10 @@ For best results with the enhanced OCR features:
 | `AUTO_TAG`                          | Tag for auto processing.                                                                                                                                                                      | No       | paperless-gpt-auto         |
 | `FAIL_TAG`                          | Tag applied to a document when paperless-gpt could not apply the full LLM suggestion. Two cases trigger it: (1) **partial success** — paperless-ngx rejected one or more fields (e.g. an LLM-suggested date in an impossible format such as `2023-01-79`); paperless-gpt drops the rejected fields, retries the update with the rest, and applies this tag so the user knows the document needs review; (2) **hard failure** — the update could not be salvaged; paperless-gpt removes the auto tag (to break the processing loop) and applies this tag; (3) **repeated OCR failure** — OCR processing of the document failed `OCR_MAX_RETRIES` times in a row; paperless-gpt removes the auto OCR tag and applies this tag. The tag is created automatically in paperless-ngx at startup if it does not exist. | No       | paperless-gpt-failed       |
 | `AUTO_TAG_COMPLETE`                 | Tag added to documents after auto-processing is complete. Only applied during auto-processing, not manual review. Set to an empty string (`AUTO_TAG_COMPLETE=""`) to disable. When the variable is unset, the default tag is used. | No       | paperless-gpt-auto-complete |
-| `LLM_PROVIDER`                      | AI backend (`openai`, `ollama`, `googleai`, `mistral`, or `anthropic`).                                                                                                                       | Yes      |                            |
+| `LLM_PROVIDER`                      | AI backend (`openai`, `atlas`, `ollama`, `googleai`, `mistral`, or `anthropic`).                                                                                                              | Yes      |                            |
 | `LLM_MODEL`                         | AI model name (e.g., `gpt-4o`, `mistral-large-latest`, `qwen3:8b`, `claude-sonnet-4-5`).                                                                                               | Yes      |                            |
 | `OPENAI_API_KEY`                    | OpenAI API key (required if using OpenAI).                                                                                                                                                    | Cond.    |                            |
+| `ATLAS_API_KEY`                     | Atlas Cloud API key (required if using `LLM_PROVIDER=atlas` or `VISION_LLM_PROVIDER=atlas`).                                                                                                  | Cond.    |                            |
 | `MISTRAL_API_KEY`                   | Mistral API key (required if using Mistral).                                                                                                                                                  | Cond.    |                            |
 | `ANTHROPIC_API_KEY`                 | Anthropic API key (required if using Anthropic/Claude).                                                                                                                                       | Cond.    |                            |
 | `OPENAI_API_TYPE`                   | Set to `azure` to use Azure OpenAI Service.                                                                                                                                                   | No       |                            |
@@ -585,7 +591,7 @@ For best results with the enhanced OCR features:
 | `SUGGESTION_JOB_TIMEOUT_SECONDS`    | Optional timeout for async manual suggestion jobs. Leave unset to disable; set a bounded value for slow local inference when jobs must not run forever.                                      | No       |                            |
 | `OCR_PROVIDER`                      | OCR provider to use (`llm`, `azure`, or `google_docai`).                                                                                                                                      | No       | llm                        |
 | `OCR_PROCESS_MODE`                  | Method for processing documents: `image` (convert to images first), `pdf` (process PDF pages directly), or `whole_pdf` (entire PDF at once).                                                  | No       | image                      |
-| `VISION_LLM_PROVIDER`               | AI backend for LLM OCR (`openai`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`.                                                                                    | Cond.    |                            |
+| `VISION_LLM_PROVIDER`               | AI backend for LLM OCR (`openai`, `atlas`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`.                                                                           | Cond.    |                            |
 | `VISION_LLM_MODEL`                  | Model name for LLM OCR (e.g. `minicpm-v`). Required if OCR_PROVIDER is `llm`.                                                                                                                 | Cond.    |                            |
 | `VISION_LLM_REQUESTS_PER_MINUTE`    | Maximum requests per minute for the Vision LLM. Useful for managing API costs or local LLM load.                                                                                              | No       | 120                        |
 | `VISION_LLM_MAX_RETRIES`            | Maximum retry attempts for failed Vision LLM requests.                                                                                                                                        | No       | 3                          |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ services:
       # OCR Configuration - Choose one:
       # Option 1: LLM-based OCR
       OCR_PROVIDER: "llm" # Default OCR provider
-      VISION_LLM_PROVIDER: "ollama" # openai, atlas, ollama, mistral, or anthropic
+      VISION_LLM_PROVIDER: "ollama" # openai, atlas, ollama, googleai, mistral, or anthropic
       VISION_LLM_MODEL: "minicpm-v" # minicpm-v (ollama) or gpt-4o (openai) or claude-sonnet-4-5 (anthropic/claude)
       OLLAMA_HOST: "http://host.docker.internal:11434" # If using Ollama
 
@@ -591,7 +591,7 @@ For best results with the enhanced OCR features:
 | `SUGGESTION_JOB_TIMEOUT_SECONDS`    | Optional timeout for async manual suggestion jobs. Leave unset to disable; set a bounded value for slow local inference when jobs must not run forever.                                      | No       |                            |
 | `OCR_PROVIDER`                      | OCR provider to use (`llm`, `azure`, or `google_docai`).                                                                                                                                      | No       | llm                        |
 | `OCR_PROCESS_MODE`                  | Method for processing documents: `image` (convert to images first), `pdf` (process PDF pages directly), or `whole_pdf` (entire PDF at once).                                                  | No       | image                      |
-| `VISION_LLM_PROVIDER`               | AI backend for LLM OCR (`openai`, `atlas`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`.                                                                           | Cond.    |                            |
+| `VISION_LLM_PROVIDER`               | AI backend for LLM OCR (`openai`, `atlas`, `ollama`, `googleai`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`.                                                               | Cond.    |                            |
 | `VISION_LLM_MODEL`                  | Model name for LLM OCR (e.g. `minicpm-v`). Required if OCR_PROVIDER is `llm`.                                                                                                                 | Cond.    |                            |
 | `VISION_LLM_REQUESTS_PER_MINUTE`    | Maximum requests per minute for the Vision LLM. Useful for managing API costs or local LLM load.                                                                                              | No       | 120                        |
 | `VISION_LLM_MAX_RETRIES`            | Maximum retry attempts for failed Vision LLM requests.                                                                                                                                        | No       | 3                          |

--- a/atlas_provider_test.go
+++ b/atlas_provider_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateLLMAtlas(t *testing.T) {
+	originalProvider, originalModel := llmProvider, llmModel
+	t.Cleanup(func() {
+		llmProvider, llmModel = originalProvider, originalModel
+	})
+
+	llmProvider = "atlas"
+	llmModel = "qwen/qwen3.8-max"
+	t.Setenv("ATLAS_API_KEY", "test-api-key")
+
+	model, err := createLLM()
+	require.NoError(t, err)
+	assert.NotNil(t, model)
+}
+
+func TestCreateLLMAtlasRequiresAPIKey(t *testing.T) {
+	originalProvider, originalModel := llmProvider, llmModel
+	t.Cleanup(func() {
+		llmProvider, llmModel = originalProvider, originalModel
+	})
+
+	llmProvider = "atlas"
+	llmModel = "qwen/qwen3.8-max"
+	t.Setenv("ATLAS_API_KEY", "")
+
+	model, err := createLLM()
+	assert.Nil(t, model)
+	assert.EqualError(t, err, "Atlas Cloud API key is not set")
+}
+
+func TestCreateVisionLLMAtlas(t *testing.T) {
+	originalProvider, originalModel := visionLlmProvider, visionLlmModel
+	t.Cleanup(func() {
+		visionLlmProvider, visionLlmModel = originalProvider, originalModel
+	})
+
+	visionLlmProvider = "atlas"
+	visionLlmModel = "qwen/qwen3-vl-235b-a22b-thinking"
+	t.Setenv("ATLAS_API_KEY", "test-api-key")
+
+	model, err := createVisionLLM()
+	require.NoError(t, err)
+	assert.NotNil(t, model)
+}

--- a/env_registry.go
+++ b/env_registry.go
@@ -113,7 +113,7 @@ var envRegistry = []EnvVar{
 	{Name: "VISION_LLM_MAX_RETRIES", Category: "OCR", Secret: false, Default: "3", Description: "Maximum retry attempts for failed Vision LLM requests."},
 	{Name: "VISION_LLM_MAX_TOKENS", Category: "OCR", Secret: false, Default: "", Description: "Maximum tokens for Vision LLM OCR output."},
 	{Name: "VISION_LLM_MODEL", Category: "OCR", Secret: false, Default: "", Description: "Model name for LLM OCR (e.g. `minicpm-v`). Required if OCR_PROVIDER is `llm`."},
-	{Name: "VISION_LLM_PROVIDER", Category: "OCR", Secret: false, Default: "", Description: "AI backend for LLM OCR (`openai`, `atlas`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`."},
+	{Name: "VISION_LLM_PROVIDER", Category: "OCR", Secret: false, Default: "", Description: "AI backend for LLM OCR (`openai`, `atlas`, `ollama`, `googleai`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`."},
 	{Name: "VISION_LLM_REQUESTS_PER_MINUTE", Category: "OCR", Secret: false, Default: "120", Description: "Maximum requests per minute for the Vision LLM. Useful for managing API costs or local LLM load."},
 	{Name: "VISION_LLM_TEMPERATURE", Category: "OCR", Secret: false, Default: "", Description: "Sampling temperature for Vision OCR generation. Lower is more deterministic. Important: For OpenAI GPT-5 it must be explicitly set to `1.0`."},
 }

--- a/env_registry.go
+++ b/env_registry.go
@@ -33,6 +33,7 @@ var envCategoryOrder = []string{
 // GOOGLE_APPLICATION_CREDENTIALS) that never appear as os.Getenv calls in Go.
 var envRegistry = []EnvVar{
 	{Name: "ANTHROPIC_API_KEY", Category: "LLM", Secret: true, Default: "", Description: "Anthropic API key (required if using Anthropic/Claude)."},
+	{Name: "ATLAS_API_KEY", Category: "LLM", Secret: true, Default: "", Description: "Atlas Cloud API key (required if using `LLM_PROVIDER=atlas` or `VISION_LLM_PROVIDER=atlas`)."},
 	{Name: "AUTO_GENERATE_CORRESPONDENTS", Category: "Tags & automation", Secret: false, Default: "true", Description: "Generate correspondents automatically if `paperless-gpt-auto` is used."},
 	{Name: "AUTO_GENERATE_CREATED_DATE", Category: "Tags & automation", Secret: false, Default: "true", Description: "Generate the created dates automatically if `paperless-gpt-auto` is used."},
 	{Name: "AUTO_GENERATE_DOCUMENT_TYPE", Category: "Tags & automation", Secret: false, Default: "true", Description: "Generate document types automatically if `paperless-gpt-auto` is used. Only existing document types from paperless-ngx will be used."},
@@ -70,7 +71,7 @@ var envRegistry = []EnvVar{
 	{Name: "LLM_LANGUAGE", Category: "Processing & limits", Secret: false, Default: "English", Description: "Likely language for documents (e.g. `English`). Appears in the prompt to help the LLM."},
 	{Name: "LLM_MAX_RETRIES", Category: "LLM", Secret: false, Default: "3", Description: "Maximum retry attempts for failed main LLM requests."},
 	{Name: "LLM_MODEL", Category: "LLM", Secret: false, Default: "", Description: "AI model name (e.g., `gpt-4o`, `mistral-large-latest`, `qwen3:8b`, `claude-sonnet-4-5`)."},
-	{Name: "LLM_PROVIDER", Category: "LLM", Secret: false, Default: "", Description: "AI backend (`openai`, `ollama`, `googleai`, `mistral`, or `anthropic`)."},
+	{Name: "LLM_PROVIDER", Category: "LLM", Secret: false, Default: "", Description: "AI backend (`openai`, `atlas`, `ollama`, `googleai`, `mistral`, or `anthropic`)."},
 	{Name: "LLM_REQUESTS_PER_MINUTE", Category: "LLM", Secret: false, Default: "120", Description: "Maximum requests per minute for the main LLM. Useful for managing API costs or local LLM load."},
 	{Name: "LOCAL_HOCR_PATH", Category: "PDF & hOCR", Secret: false, Default: "/app/hocr", Description: "Path where hOCR files will be saved when hOCR generation is enabled."},
 	{Name: "LOCAL_PDF_PATH", Category: "PDF & hOCR", Secret: false, Default: "/app/pdf", Description: "Path where PDF files will be saved when PDF generation is enabled."},
@@ -112,7 +113,7 @@ var envRegistry = []EnvVar{
 	{Name: "VISION_LLM_MAX_RETRIES", Category: "OCR", Secret: false, Default: "3", Description: "Maximum retry attempts for failed Vision LLM requests."},
 	{Name: "VISION_LLM_MAX_TOKENS", Category: "OCR", Secret: false, Default: "", Description: "Maximum tokens for Vision LLM OCR output."},
 	{Name: "VISION_LLM_MODEL", Category: "OCR", Secret: false, Default: "", Description: "Model name for LLM OCR (e.g. `minicpm-v`). Required if OCR_PROVIDER is `llm`."},
-	{Name: "VISION_LLM_PROVIDER", Category: "OCR", Secret: false, Default: "", Description: "AI backend for LLM OCR (`openai`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`."},
+	{Name: "VISION_LLM_PROVIDER", Category: "OCR", Secret: false, Default: "", Description: "AI backend for LLM OCR (`openai`, `atlas`, `ollama`, `mistral`, or `anthropic`). Required if OCR_PROVIDER is `llm`."},
 	{Name: "VISION_LLM_REQUESTS_PER_MINUTE", Category: "OCR", Secret: false, Default: "120", Description: "Maximum requests per minute for the Vision LLM. Useful for managing API costs or local LLM load."},
 	{Name: "VISION_LLM_TEMPERATURE", Category: "OCR", Secret: false, Default: "", Description: "Sampling temperature for Vision OCR generation. Lower is more deterministic. Important: For OpenAI GPT-5 it must be explicitly set to `1.0`."},
 }

--- a/main.go
+++ b/main.go
@@ -699,15 +699,16 @@ func validateOrDefaultEnvVars() {
 
 	if visionLlmProvider != "" &&
 		visionLlmProvider != "openai" &&
+		visionLlmProvider != "atlas" &&
 		visionLlmProvider != "ollama" &&
 		visionLlmProvider != "mistral" &&
 		visionLlmProvider != "googleai" &&
 		visionLlmProvider != "anthropic" {
 
-		log.Fatal("Please set the VISION_LLM_PROVIDER environment variable to 'openai', 'ollama', 'googleai', 'mistral' or 'anthropic'.")
+		log.Fatal("Please set the VISION_LLM_PROVIDER environment variable to 'openai', 'atlas', 'ollama', 'googleai', 'mistral' or 'anthropic'.")
 	}
-	if llmProvider != "openai" && llmProvider != "ollama" && llmProvider != "googleai" && llmProvider != "mistral" && llmProvider != "anthropic" {
-		log.Fatal("Please set the LLM_PROVIDER environment variable to 'openai', 'ollama', 'googleai', 'mistral' or 'anthropic'.")
+	if llmProvider != "openai" && llmProvider != "atlas" && llmProvider != "ollama" && llmProvider != "googleai" && llmProvider != "mistral" && llmProvider != "anthropic" {
+		log.Fatal("Please set the LLM_PROVIDER environment variable to 'openai', 'atlas', 'ollama', 'googleai', 'mistral' or 'anthropic'.")
 	}
 
 	// Validate OCR provider if set
@@ -761,6 +762,11 @@ func validateOrDefaultEnvVars() {
 			if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL == "" {
 				log.Fatal("Please set the OPENAI_BASE_URL environment variable for Azure OpenAI.")
 			}
+		}
+	}
+	if llmProvider == "atlas" || visionLlmProvider == "atlas" {
+		if os.Getenv("ATLAS_API_KEY") == "" {
+			log.Fatal("Please set the ATLAS_API_KEY environment variable for Atlas Cloud provider.")
 		}
 	}
 
@@ -1080,6 +1086,21 @@ func createLLM() (llms.Model, error) {
 
 		// Apply rate limiting with isVision=false
 		return NewRateLimitedLLM(llm, getRateLimitConfig(false)), nil
+	case "atlas":
+		apiKey := os.Getenv("ATLAS_API_KEY")
+		if apiKey == "" {
+			return nil, fmt.Errorf("Atlas Cloud API key is not set")
+		}
+		llm, err := openai.New(
+			openai.WithModel(llmModel),
+			openai.WithToken(apiKey),
+			openai.WithBaseURL("https://api.atlascloud.ai/v1"),
+			openai.WithHTTPClient(createCustomHTTPClient()),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return NewRateLimitedLLM(llm, getRateLimitConfig(false)), nil
 	case "ollama":
 		host := os.Getenv("OLLAMA_HOST")
 		if host == "" {
@@ -1149,7 +1170,7 @@ func createLLM() (llms.Model, error) {
 		// Apply rate limiting with isVision=false
 		return NewRateLimitedLLM(llm, getRateLimitConfig(false)), nil
 	default:
-		return nil, fmt.Errorf("unsupported LLM provider: %s (supported: openai, ollama, mistral, googleai, anthropic)", llmProvider)
+		return nil, fmt.Errorf("unsupported LLM provider: %s (supported: openai, atlas, ollama, mistral, googleai, anthropic)", llmProvider)
 	}
 }
 
@@ -1205,6 +1226,21 @@ func createVisionLLM() (llms.Model, error) {
 
 		// Apply rate limiting with isVision=true
 		return NewRateLimitedLLM(llm, getRateLimitConfig(true)), nil
+	case "atlas":
+		apiKey := os.Getenv("ATLAS_API_KEY")
+		if apiKey == "" {
+			return nil, fmt.Errorf("Atlas Cloud API key is not set")
+		}
+		llm, err := openai.New(
+			openai.WithModel(visionLlmModel),
+			openai.WithToken(apiKey),
+			openai.WithBaseURL("https://api.atlascloud.ai/v1"),
+			openai.WithHTTPClient(createCustomHTTPClient()),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return NewRateLimitedLLM(llm, getRateLimitConfig(true)), nil
 	case "ollama":
 		host := os.Getenv("OLLAMA_HOST")
 		if host == "" {
@@ -1259,7 +1295,6 @@ func createVisionLLM() (llms.Model, error) {
 		return nil, nil
 	}
 }
-
 
 func createCustomHTTPClient() *http.Client {
 	// Create custom transport that adds headers

--- a/ocr/atlas_provider_test.go
+++ b/ocr/atlas_provider_test.go
@@ -1,0 +1,39 @@
+package ocr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAtlasClient(t *testing.T) {
+	t.Setenv("ATLAS_API_KEY", "test-api-key")
+
+	client, err := createAtlasClient(Config{VisionLLMModel: "qwen/qwen3-vl-235b-a22b-thinking"})
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}
+
+func TestCreateAtlasClientRequiresAPIKey(t *testing.T) {
+	t.Setenv("ATLAS_API_KEY", "")
+
+	client, err := createAtlasClient(Config{VisionLLMModel: "qwen/qwen3-vl-235b-a22b-thinking"})
+	assert.Nil(t, client)
+	assert.EqualError(t, err, "Atlas Cloud API key is not set")
+}
+
+func TestNewLLMProviderAtlas(t *testing.T) {
+	t.Setenv("ATLAS_API_KEY", "test-api-key")
+	config := Config{
+		VisionLLMProvider: "atlas",
+		VisionLLMModel:    "qwen/qwen3-vl-235b-a22b-thinking",
+		VisionLLMPrompt:   "Extract text from this image",
+	}
+
+	provider, err := newLLMProvider(config)
+	require.NoError(t, err)
+	assert.Equal(t, "atlas", provider.provider)
+	assert.Equal(t, config.VisionLLMModel, provider.model)
+	assert.Equal(t, config.VisionLLMPrompt, provider.prompt)
+}

--- a/ocr/llm_provider.go
+++ b/ocr/llm_provider.go
@@ -61,6 +61,9 @@ func newLLMProvider(config Config) (*LLMProvider, error) {
 	case "openai":
 		logger.Debug("Initializing OpenAI vision model")
 		model, err = createOpenAIClient(config)
+	case "atlas":
+		logger.Debug("Initializing Atlas Cloud vision model")
+		model, err = createAtlasClient(config)
 	case "ollama":
 		logger.Debug("Initializing Ollama vision model")
 		model, err = createOllamaClient(config)
@@ -132,7 +135,7 @@ func (p *LLMProvider) ProcessImage(ctx context.Context, imageContent []byte, pag
 	var parts []llms.ContentPart
 	var contentPart llms.ContentPart
 
-	if providerName == "openai" || providerName == "mistral" {
+	if providerName == "openai" || providerName == "atlas" || providerName == "mistral" {
 		logger.Info("Using OpenAI image format")
 		contentPart = llms.ImageURLPart("data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(imageContent))
 	} else if providerName == "googleai" {
@@ -224,6 +227,18 @@ func createOpenAIClient(config Config) (llms.Model, error) {
 	return openai.New(
 		openai.WithModel(config.VisionLLMModel),
 		openai.WithToken(apiKey),
+	)
+}
+
+func createAtlasClient(config Config) (llms.Model, error) {
+	apiKey := os.Getenv("ATLAS_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("Atlas Cloud API key is not set")
+	}
+	return openai.New(
+		openai.WithModel(config.VisionLLMModel),
+		openai.WithToken(apiKey),
+		openai.WithBaseURL("https://api.atlascloud.ai/v1"),
 	)
 }
 


### PR DESCRIPTION
Closes #1041

## Summary

- add `atlas` as a first-class text and vision LLM provider
- configure the fixed Atlas Cloud OpenAI-compatible endpoint through `ATLAS_API_KEY`
- support Atlas vision models in the OCR image path
- document Docker and environment configuration
- add focused provider construction and validation tests

## Validation

- `go test ./ocr .`
- `go test ./...`
- `go build -o /tmp/paperless-gpt-atlas-check .`
- `npm run build`
- live Atlas text request with `qwen/qwen3.8-max`
- live Atlas vision OCR request with `qwen/qwen3-vl-235b-a22b-thinking`

`npm run lint` still reports existing errors in `web-app/e2e/setup/global-setup.ts`, `web-app/src/AdhocAnalysis.tsx`, and `web-app/src/components/PromptsEditor.tsx`; this PR does not modify frontend source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as a supported text, vision, and OCR provider.
  * Added configuration support for `ATLAS_API_KEY`.
  * Added Atlas provider options to documented environment settings and Docker Compose examples.
  * Added API-key validation and support for Atlas-compatible image processing.

* **Tests**
  * Added coverage for successful Atlas setup and missing API-key errors across text, vision, and OCR features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->