### PR TITLE
fix(ocr): preserve explicit zero page limit

### DIFF
--- a/ocr.go
+++ b/ocr.go
@@ -170,11 +170,9 @@ func (app *App) ProcessDocumentOCR(ctx context.Context, documentID int, options 
 		docLogger.Debug("OCR provider does not support hOCR")
 	}
 
-	// Use the page limit from options if provided, otherwise use the global setting
-	pageLimit := limitOcrPages
-	if options.LimitPages > 0 {
-		pageLimit = options.LimitPages
-	}
+	// Run options are resolved against saved/env defaults before processing.
+	// Keep an explicit zero here: it means process every page.
+	pageLimit := options.LimitPages
 
 	var ocrTexts []string
 	var imageDataList [][]byte

--- a/ocr_test.go
+++ b/ocr_test.go
@@ -11,10 +11,58 @@ import (
 	"testing"
 	"time"
 
+	"paperless-gpt/ocr"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type recordingOCRProvider struct {
+	pages []int
+}
+
+func (p *recordingOCRProvider) ProcessImage(_ context.Context, _ []byte, pageNumber int) (*ocr.OCRResult, error) {
+	p.pages = append(p.pages, pageNumber)
+	return &ocr.OCRResult{Text: fmt.Sprintf("page %d", pageNumber)}, nil
+}
+
+func TestProcessDocumentOCR_ExplicitZeroPageLimitProcessesAllPages(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.teardown()
+	require.NoError(t, env.db.AutoMigrate(&OCRPageResult{}))
+
+	pdfContent, err := os.ReadFile("tests/pdf/five-pager.pdf")
+	require.NoError(t, err)
+
+	const documentID = 1037
+	env.setMockResponse(fmt.Sprintf("/api/documents/%d/download/", documentID), func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(pdfContent)
+	})
+	env.client.CacheFolder = t.TempDir()
+
+	previousGlobalLimit := limitOcrPages
+	limitOcrPages = 2
+	t.Cleanup(func() { limitOcrPages = previousGlobalLimit })
+
+	provider := &recordingOCRProvider{}
+	app := &App{
+		Client:             env.client,
+		Database:           env.db,
+		ocrProvider:        provider,
+		ocrProcessMode:     "image",
+		pdfSkipExistingOCR: false,
+	}
+
+	_, err = app.ProcessDocumentOCR(context.Background(), documentID, OCROptions{
+		LimitPages:     0,
+		ProcessMode:    "image",
+		PromptOverride: "OCR",
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, provider.pages)
+}
 
 // This test focuses on verifying the PDF safety feature without using mocks that implement interfaces
 func TestProcessDocumentOCR_SafetyFeature(t *testing.T) {


### PR DESCRIPTION
## Summary

- Closes #1037.
- Fixes: An OCR job saved with LimitPages=0, documented as no limit, silently processes only the global default number of pages and still reports success.
- Root cause: ProcessDocumentOCR treats the already-resolved integer run option as optional and only copies positive values, so the meaningful zero value is replaced by the global limit a second time.

The run options are already resolved against saved and environment defaults before `ProcessDocumentOCR` is called. The processing layer now preserves that resolved value, including the meaningful zero value used by the PDF/image splitters for unlimited pages.

## Regression evidence

- Before: `go test ./... -run '^TestProcessDocumentOCR_ExplicitZeroPageLimitProcessesAllPages$' -count=1` exited `1`

- After: `go test ./... -run '^TestProcessDocumentOCR_ExplicitZeroPageLimitProcessesAllPages$' -count=1` exited `0`

## Verification

- `go test ./...`
- `go vet ./...`
- `cd web-app && npm run build`
- `test -z "$(gofmt -l ocr.go)" && git diff --check`

`cd web-app && npm run lint` was also run. It reports seven existing errors in unchanged frontend files (`global-setup.ts`, `AdhocAnalysis.tsx`, and `PromptsEditor.tsx`); this PR has no frontend diff.

## Scope

- 2 files changed, +51 / -5 lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setting the per-document page limit to zero now processes all pages, as expected.
  * Per-document page limits are no longer incorrectly overridden by the global page limit.

* **Tests**
  * Added coverage confirming that all pages are processed when no per-document limit is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->