### PR TITLE
feat: duplicate workflows and filter by name/prompt

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           # Set repository names
           DOCKERHUB_REPO="icereed/paperless-gpt"
-          GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY}"
+          GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY,,}"
 
           # For forks, only use GHCR
           if [[ "${GITHUB_REPOSITORY}" != "icereed/paperless-gpt" ]]; then
@@ -165,7 +165,7 @@ jobs:
         run: |
           # Set repository names
           DOCKERHUB_REPO="icereed/paperless-gpt"
-          GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY}"
+          GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY,,}"
 
           # For forks, only use GHCR
           if [[ "${GITHUB_REPOSITORY}" != "icereed/paperless-gpt" ]]; then
@@ -213,7 +213,6 @@ jobs:
     if: github.event_name != 'pull_request'
     env:
       DOCKERHUB_REPO: icereed/paperless-gpt
-      GHCR_REPO: ghcr.io/${{ github.repository }}
     steps:
       - name: Download amd64 digest
         uses: actions/download-artifact@v7
@@ -242,6 +241,7 @@ jobs:
       - name: Determine version/tag
         id: get_version
         run: |
+          echo "GHCR_REPO=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             echo "VERSION=${VERSION}" >> $GITHUB_ENV
@@ -390,7 +390,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Set PAPERLESS_GPT_IMAGE
         run: |
-          GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY}"
+          GHCR_REPO="ghcr.io/${GITHUB_REPOSITORY,,}"
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             IMAGE="${GHCR_REPO}:${GITHUB_REF_NAME}-amd64"
           else

--- a/app_http_handlers.go
+++ b/app_http_handlers.go
@@ -1092,3 +1092,155 @@ func getVersionHandler(c *gin.Context) {
 func containsDotDot(s string) bool {
 	return strings.Contains(s, "..")
 }
+
+// ---------------------------------------------------------------------------
+// Workflow CRUD handlers
+// ---------------------------------------------------------------------------
+
+// listWorkflowsHandler handles GET /api/workflows – returns all configured workflows.
+func (app *App) listWorkflowsHandler(c *gin.Context) {
+	settingsMutex.RLock()
+	wfs := make([]WorkflowConfig, len(settings.Workflows))
+	copy(wfs, settings.Workflows)
+	settingsMutex.RUnlock()
+	c.JSON(http.StatusOK, wfs)
+}
+
+// createWorkflowHandler handles POST /api/workflows – creates a new workflow.
+func (app *App) createWorkflowHandler(c *gin.Context) {
+	var wf WorkflowConfig
+	if err := c.ShouldBindJSON(&wf); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+		return
+	}
+	if wf.TriggerTag == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "trigger_tag is required"})
+		return
+	}
+
+	settingsMutex.Lock()
+	defer settingsMutex.Unlock()
+
+	// Auto-generate a stable ID if not provided.
+	if wf.ID == "" {
+		wf.ID = generateWorkflowID(wf.TriggerTag, settings.Workflows)
+	}
+	// Reject duplicates.
+	for _, existing := range settings.Workflows {
+		if existing.ID == wf.ID {
+			c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("workflow with id %q already exists", wf.ID)})
+			return
+		}
+		if existing.TriggerTag == wf.TriggerTag {
+			c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("trigger_tag %q is already used by workflow %q", wf.TriggerTag, existing.ID)})
+			return
+		}
+	}
+
+	settings.Workflows = append(settings.Workflows, wf)
+	if err := saveSettingsLocked(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
+		return
+	}
+	invalidateWorkflowTemplateCache(wf.ID)
+	c.JSON(http.StatusCreated, wf)
+}
+
+// updateWorkflowHandler handles PUT /api/workflows/:id – replaces a workflow.
+func (app *App) updateWorkflowHandler(c *gin.Context) {
+	id := c.Param("id")
+	var wf WorkflowConfig
+	if err := c.ShouldBindJSON(&wf); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+		return
+	}
+	wf.ID = id // enforce path ID
+
+	settingsMutex.Lock()
+	defer settingsMutex.Unlock()
+
+	found := false
+	for i, existing := range settings.Workflows {
+		if existing.ID == id {
+			// Ensure the new trigger_tag is not used by another workflow.
+			for j, other := range settings.Workflows {
+				if j != i && other.TriggerTag == wf.TriggerTag && wf.TriggerTag != "" {
+					c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("trigger_tag %q is already used by workflow %q", wf.TriggerTag, other.ID)})
+					return
+				}
+			}
+			settings.Workflows[i] = wf
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("workflow %q not found", id)})
+		return
+	}
+	if err := saveSettingsLocked(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
+		return
+	}
+	invalidateWorkflowTemplateCache(id)
+	c.JSON(http.StatusOK, wf)
+}
+
+// deleteWorkflowHandler handles DELETE /api/workflows/:id – removes a workflow.
+func (app *App) deleteWorkflowHandler(c *gin.Context) {
+	id := c.Param("id")
+
+	settingsMutex.Lock()
+	defer settingsMutex.Unlock()
+
+	newWorkflows := make([]WorkflowConfig, 0, len(settings.Workflows))
+	found := false
+	for _, wf := range settings.Workflows {
+		if wf.ID == id {
+			found = true
+			continue
+		}
+		newWorkflows = append(newWorkflows, wf)
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("workflow %q not found", id)})
+		return
+	}
+	settings.Workflows = newWorkflows
+	if err := saveSettingsLocked(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
+		return
+	}
+	invalidateWorkflowTemplateCache(id)
+	c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("workflow %q deleted", id)})
+}
+
+// generateWorkflowID creates a URL-safe workflow ID from the trigger tag,
+// appending a numeric suffix when necessary to avoid collisions.
+func generateWorkflowID(triggerTag string, existing []WorkflowConfig) string {
+	base := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			return r
+		}
+		if r >= 'A' && r <= 'Z' {
+			return r + 32 // to lower
+		}
+		return '-'
+	}, triggerTag)
+
+	// Trim leading/trailing dashes.
+	base = strings.Trim(base, "-")
+	if base == "" {
+		base = "workflow"
+	}
+
+	id := base
+	used := map[string]bool{}
+	for _, wf := range existing {
+		used[wf.ID] = true
+	}
+	for i := 2; used[id]; i++ {
+		id = fmt.Sprintf("%s-%d", base, i)
+	}
+	return id
+}

--- a/app_llm.go
+++ b/app_llm.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	_ "image/jpeg"
@@ -19,12 +20,17 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-// getSuggestedCorrespondent generates a suggested correspondent for a document using the LLM
-func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, suggestedTitle string, availableCorrespondents []string, correspondentBlackList []string) (string, error) {
+// getSuggestedCorrespondent generates a suggested correspondent for a document using the LLM.
+// tmplOverride, when non-nil, replaces the global correspondentTemplate for this call.
+func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, suggestedTitle string, availableCorrespondents []string, correspondentBlackList []string, tmplOverride *template.Template) (string, error) {
 	likelyLanguage := getLikelyLanguage()
 
 	templateMutex.RLock()
-	defer templateMutex.RUnlock()
+	activeTmpl := correspondentTemplate
+	templateMutex.RUnlock()
+	if tmplOverride != nil {
+		activeTmpl = tmplOverride
+	}
 
 	// Get available tokens for content
 	templateData := map[string]interface{}{
@@ -34,7 +40,7 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 		"Title":                   suggestedTitle,
 	}
 
-	availableTokens, err := getAvailableTokensForContent(correspondentTemplate, templateData)
+	availableTokens, err := getAvailableTokensForContent(activeTmpl, templateData)
 	if err != nil {
 		return "", fmt.Errorf("error calculating available tokens: %v", err)
 	}
@@ -48,7 +54,7 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 	// Execute template with truncated content
 	var promptBuffer bytes.Buffer
 	templateData["Content"] = truncatedContent
-	err = correspondentTemplate.Execute(&promptBuffer, templateData)
+	err = activeTmpl.Execute(&promptBuffer, templateData)
 	if err != nil {
 		return "", fmt.Errorf("error executing correspondent template: %v", err)
 	}
@@ -74,18 +80,24 @@ func (app *App) getSuggestedCorrespondent(ctx context.Context, content string, s
 	return response, nil
 }
 
-// getSuggestedTags generates suggested tags for a document using the LLM
+// getSuggestedTags generates suggested tags for a document using the LLM.
+// tmplOverride, when non-nil, replaces the global tagTemplate for this call.
 func (app *App) getSuggestedTags(
 	ctx context.Context,
 	content string,
 	suggestedTitle string,
 	availableTags []string,
 	originalTags []string,
-	logger *logrus.Entry) ([]string, error) {
+	logger *logrus.Entry,
+	tmplOverride *template.Template) ([]string, error) {
 	likelyLanguage := getLikelyLanguage()
 
 	templateMutex.RLock()
-	defer templateMutex.RUnlock()
+	activeTmpl := tagTemplate
+	templateMutex.RUnlock()
+	if tmplOverride != nil {
+		activeTmpl = tmplOverride
+	}
 
 	// Remove all paperless-gpt related tags from available tags
 	availableTags = removeTagFromList(availableTags, manualTag)
@@ -101,7 +113,7 @@ func (app *App) getSuggestedTags(
 		"CreateNewTags": createNewTags,
 	}
 
-	availableTokens, err := getAvailableTokensForContent(tagTemplate, templateData)
+	availableTokens, err := getAvailableTokensForContent(activeTmpl, templateData)
 	if err != nil {
 		logger.Errorf("Error calculating available tokens: %v", err)
 		return nil, fmt.Errorf("error calculating available tokens: %v", err)
@@ -117,7 +129,7 @@ func (app *App) getSuggestedTags(
 	// Execute template with truncated content
 	var promptBuffer bytes.Buffer
 	templateData["Content"] = truncatedContent
-	err = tagTemplate.Execute(&promptBuffer, templateData)
+	err = activeTmpl.Execute(&promptBuffer, templateData)
 	if err != nil {
 		logger.Errorf("Error executing tag template: %v", err)
 		return nil, fmt.Errorf("error executing tag template: %v", err)
@@ -190,17 +202,23 @@ func (app *App) getSuggestedTags(
 	return filteredTags, nil
 }
 
-// getSuggestedDocumentType generates a suggested document type for a document using the LLM
+// getSuggestedDocumentType generates a suggested document type for a document using the LLM.
+// tmplOverride, when non-nil, replaces the global documentTypeTemplate for this call.
 func (app *App) getSuggestedDocumentType(
 	ctx context.Context,
 	content string,
 	suggestedTitle string,
 	availableDocumentTypes []string,
-	logger *logrus.Entry) (string, error) {
+	logger *logrus.Entry,
+	tmplOverride *template.Template) (string, error) {
 	likelyLanguage := getLikelyLanguage()
 
 	templateMutex.RLock()
-	defer templateMutex.RUnlock()
+	activeTmpl := documentTypeTemplate
+	templateMutex.RUnlock()
+	if tmplOverride != nil {
+		activeTmpl = tmplOverride
+	}
 
 	// Get available tokens for content
 	templateData := map[string]interface{}{
@@ -209,7 +227,7 @@ func (app *App) getSuggestedDocumentType(
 		"Title":                  suggestedTitle,
 	}
 
-	availableTokens, err := getAvailableTokensForContent(documentTypeTemplate, templateData)
+	availableTokens, err := getAvailableTokensForContent(activeTmpl, templateData)
 	if err != nil {
 		logger.Errorf("Error calculating available tokens: %v", err)
 		return "", fmt.Errorf("error calculating available tokens: %v", err)
@@ -225,7 +243,7 @@ func (app *App) getSuggestedDocumentType(
 	// Execute template with truncated content
 	var promptBuffer bytes.Buffer
 	templateData["Content"] = truncatedContent
-	err = documentTypeTemplate.Execute(&promptBuffer, templateData)
+	err = activeTmpl.Execute(&promptBuffer, templateData)
 	if err != nil {
 		logger.Errorf("Error executing document type template: %v", err)
 		return "", fmt.Errorf("error executing document type template: %v", err)
@@ -265,12 +283,17 @@ func (app *App) getSuggestedDocumentType(
 	return "", nil
 }
 
-// getSuggestedTitle generates a suggested title for a document using the LLM
-func (app *App) getSuggestedTitle(ctx context.Context, content string, originalTitle string, logger *logrus.Entry) (string, error) {
+// getSuggestedTitle generates a suggested title for a document using the LLM.
+// tmplOverride, when non-nil, replaces the global titleTemplate for this call.
+func (app *App) getSuggestedTitle(ctx context.Context, content string, originalTitle string, logger *logrus.Entry, tmplOverride *template.Template) (string, error) {
 	likelyLanguage := getLikelyLanguage()
 
 	templateMutex.RLock()
-	defer templateMutex.RUnlock()
+	activeTmpl := titleTemplate
+	templateMutex.RUnlock()
+	if tmplOverride != nil {
+		activeTmpl = tmplOverride
+	}
 
 	// Get available tokens for content
 	templateData := map[string]interface{}{
@@ -279,7 +302,7 @@ func (app *App) getSuggestedTitle(ctx context.Context, content string, originalT
 		"Title":    originalTitle,
 	}
 
-	availableTokens, err := getAvailableTokensForContent(titleTemplate, templateData)
+	availableTokens, err := getAvailableTokensForContent(activeTmpl, templateData)
 	if err != nil {
 		logger.Errorf("Error calculating available tokens: %v", err)
 		return "", fmt.Errorf("error calculating available tokens: %v", err)
@@ -295,7 +318,7 @@ func (app *App) getSuggestedTitle(ctx context.Context, content string, originalT
 	// Execute template with truncated content
 	var promptBuffer bytes.Buffer
 	templateData["Content"] = truncatedContent
-	err = titleTemplate.Execute(&promptBuffer, templateData)
+	err = activeTmpl.Execute(&promptBuffer, templateData)
 
 	if err != nil {
 		return "", fmt.Errorf("error executing title template: %v", err)
@@ -321,12 +344,17 @@ func (app *App) getSuggestedTitle(ctx context.Context, content string, originalT
 	return strings.TrimSpace(strings.Trim(result, "\"")), nil
 }
 
-// getSuggestedCreatedDate generates a suggested createdDate for a document using the LLM
-func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, logger *logrus.Entry) (string, error) {
+// getSuggestedCreatedDate generates a suggested createdDate for a document using the LLM.
+// tmplOverride, when non-nil, replaces the global createdDateTemplate for this call.
+func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, logger *logrus.Entry, tmplOverride *template.Template) (string, error) {
 	likelyLanguage := getLikelyLanguage()
 
 	templateMutex.RLock()
-	defer templateMutex.RUnlock()
+	activeTmpl := createdDateTemplate
+	templateMutex.RUnlock()
+	if tmplOverride != nil {
+		activeTmpl = tmplOverride
+	}
 
 	// Get available tokens for content
 	templateData := map[string]interface{}{
@@ -335,7 +363,7 @@ func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, log
 		"Today":    getTodayDate(), // must be in YYYY-MM-DD format
 	}
 
-	availableTokens, err := getAvailableTokensForContent(createdDateTemplate, templateData)
+	availableTokens, err := getAvailableTokensForContent(activeTmpl, templateData)
 	if err != nil {
 		logger.Errorf("Error calculating available tokens: %v", err)
 		return "", fmt.Errorf("error calculating available tokens: %v", err)
@@ -351,7 +379,7 @@ func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, log
 	// Execute template with truncated content
 	var promptBuffer bytes.Buffer
 	templateData["Content"] = truncatedContent
-	err = createdDateTemplate.Execute(&promptBuffer, templateData)
+	err = activeTmpl.Execute(&promptBuffer, templateData)
 
 	if err != nil {
 		return "", fmt.Errorf("error executing createdDate template: %v", err)
@@ -578,6 +606,33 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 	startTime := time.Now()
 	docLogger.Printf("Processing Document ID %d...", documentID)
 
+	// Resolve workflow overrides (templates + generation flags).
+	var activeWorkflow WorkflowConfig
+	var hasWorkflow bool
+	if suggestionRequest.WorkflowID != "" {
+		activeWorkflow, hasWorkflow = getWorkflowByID(suggestionRequest.WorkflowID)
+		if hasWorkflow {
+			suggestionRequest = resolveGenerationFlags(suggestionRequest, activeWorkflow)
+			docLogger.Infof("Using workflow %q (trigger: %s)", activeWorkflow.Name, activeWorkflow.TriggerTag)
+		}
+	}
+
+	// Helper to look up a workflow template override (nil when no override or no workflow).
+	wfTemplate := func(promptName string, globalTmpl *template.Template) *template.Template {
+		if !hasWorkflow {
+			return nil
+		}
+		tmpl, err := getWorkflowTemplate(activeWorkflow, promptName, globalTmpl)
+		if err != nil {
+			docLogger.Warnf("Workflow template error for %q: %v – falling back to global", promptName, err)
+			return nil
+		}
+		if tmpl == globalTmpl {
+			return nil // no override; signal callers to use global
+		}
+		return tmpl
+	}
+
 	content := sanitize.Sanitize(doc.Content)
 	suggestedTitle := doc.Title
 	var suggestedTags []string
@@ -588,7 +643,7 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 	var err error
 
 	if suggestionRequest.GenerateTitles {
-		suggestedTitle, err = app.getSuggestedTitle(ctx, content, suggestedTitle, docLogger)
+		suggestedTitle, err = app.getSuggestedTitle(ctx, content, suggestedTitle, docLogger, wfTemplate("title_prompt", titleTemplate))
 		if err != nil {
 			docLogger.Errorf("Error processing document %d: %v", documentID, err)
 			return DocumentSuggestion{}, fmt.Errorf("Document %d: %v", documentID, err)
@@ -596,7 +651,7 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 	}
 
 	if suggestionRequest.GenerateTags {
-		suggestedTags, err = app.getSuggestedTags(ctx, content, suggestedTitle, generationContext.availableTagNames, doc.Tags, docLogger)
+		suggestedTags, err = app.getSuggestedTags(ctx, content, suggestedTitle, generationContext.availableTagNames, doc.Tags, docLogger, wfTemplate("tag_prompt", tagTemplate))
 		if err != nil {
 			logger.Errorf("Error generating tags for document %d: %v", documentID, err)
 			return DocumentSuggestion{}, fmt.Errorf("Document %d: %v", documentID, err)
@@ -604,7 +659,7 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 	}
 
 	if suggestionRequest.GenerateCorrespondents {
-		suggestedCorrespondent, err = app.getSuggestedCorrespondent(ctx, content, suggestedTitle, generationContext.availableCorrespondentNames, correspondentBlackList)
+		suggestedCorrespondent, err = app.getSuggestedCorrespondent(ctx, content, suggestedTitle, generationContext.availableCorrespondentNames, correspondentBlackList, wfTemplate("correspondent_prompt", correspondentTemplate))
 		if err != nil {
 			log.Errorf("Error generating correspondents for document %d: %v", documentID, err)
 			return DocumentSuggestion{}, fmt.Errorf("Document %d: %v", documentID, err)
@@ -615,7 +670,7 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 		if len(generationContext.availableDocumentTypeNames) == 0 {
 			docLogger.Debug("Document type generation is enabled, but no document types are available in paperless-ngx.")
 		} else {
-			suggestedDocumentType, err = app.getSuggestedDocumentType(ctx, content, suggestedTitle, generationContext.availableDocumentTypeNames, docLogger)
+			suggestedDocumentType, err = app.getSuggestedDocumentType(ctx, content, suggestedTitle, generationContext.availableDocumentTypeNames, docLogger, wfTemplate("document_type_prompt", documentTypeTemplate))
 			if err != nil {
 				log.Errorf("Error generating document type for document %d: %v", documentID, err)
 				return DocumentSuggestion{}, fmt.Errorf("Document %d: %v", documentID, err)
@@ -624,7 +679,7 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 	}
 
 	if suggestionRequest.GenerateCreatedDate {
-		suggestedCreatedDate, err = app.getSuggestedCreatedDate(ctx, content, docLogger)
+		suggestedCreatedDate, err = app.getSuggestedCreatedDate(ctx, content, docLogger, wfTemplate("date_prompt", createdDateTemplate))
 		if err != nil {
 			log.Errorf("Error generating createdDate for document %d: %v", documentID, err)
 			return DocumentSuggestion{}, fmt.Errorf("Document %d: %v", documentID, err)
@@ -709,6 +764,17 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 	if app.autoTagComplete != "" && suggestionRequest.IsAutoProcessing {
 		suggestion.AddTags = append(suggestion.AddTags, app.autoTagComplete)
 		docLogger.Debugf("Adding auto-processing complete tag '%s'", app.autoTagComplete)
+	}
+
+	// Workflow-specific: remove the workflow trigger tag and add the completion tag.
+	if hasWorkflow && suggestionRequest.IsAutoProcessing {
+		if activeWorkflow.TriggerTag != "" && activeWorkflow.TriggerTag != autoTag {
+			suggestion.RemoveTags = append(suggestion.RemoveTags, activeWorkflow.TriggerTag)
+		}
+		if activeWorkflow.CompletionTag != "" {
+			suggestion.AddTags = append(suggestion.AddTags, activeWorkflow.CompletionTag)
+			docLogger.Debugf("Adding workflow completion tag '%s'", activeWorkflow.CompletionTag)
+		}
 	}
 
 	elapsed := time.Since(startTime)

--- a/app_llm.go
+++ b/app_llm.go
@@ -420,8 +420,9 @@ var xmlTextEscaper = strings.NewReplacer(
 
 func escapeXMLAttr(s string) string { return xmlAttrEscaper.Replace(s) }
 func escapeXMLText(s string) string { return xmlTextEscaper.Replace(s) }
-// getSuggestedCustomFields generates suggested custom fields for a document using the LLM
-func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, selectedFieldIDs []int, logger *logrus.Entry) ([]CustomFieldSuggestion, error) {
+// getSuggestedCustomFields generates suggested custom fields for a document using the LLM.
+// tmplOverride, when non-nil, replaces the global customFieldTemplate for this call.
+func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, selectedFieldIDs []int, logger *logrus.Entry, tmplOverride *template.Template) ([]CustomFieldSuggestion, error) {
 	// Fetch all available custom fields
 	allCustomFields, err := app.Client.GetCustomFields(ctx)
 	if err != nil {
@@ -461,7 +462,11 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 	customFieldsXML := xmlBuilder.String()
 
 	templateMutex.RLock()
-	defer templateMutex.RUnlock()
+	activeTmpl := customFieldTemplate
+	templateMutex.RUnlock()
+	if tmplOverride != nil {
+		activeTmpl = tmplOverride
+	}
 
 	templateData := map[string]interface{}{
 		"Language":        getLikelyLanguage(),
@@ -471,7 +476,7 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 		"CustomFieldsXML": customFieldsXML,
 	}
 
-	availableTokens, err := getAvailableTokensForContent(customFieldTemplate, templateData)
+	availableTokens, err := getAvailableTokensForContent(activeTmpl, templateData)
 	if err != nil {
 		return nil, fmt.Errorf("error calculating available tokens for custom fields: %v", err)
 	}
@@ -483,7 +488,7 @@ func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, sele
 
 	var promptBuffer bytes.Buffer
 	templateData["Content"] = truncatedContent
-	err = customFieldTemplate.Execute(&promptBuffer, templateData)
+	err = activeTmpl.Execute(&promptBuffer, templateData)
 	if err != nil {
 		return nil, fmt.Errorf("error executing custom field template: %v", err)
 	}
@@ -694,7 +699,7 @@ func (app *App) generateSingleDocumentSuggestion(ctx context.Context, suggestion
 		if len(selectedIDs) == 0 {
 			log.Warnf("Custom field generation is enabled, but no custom fields are selected in the settings. Please select at least one custom field for this feature to work.")
 		} else {
-			suggestedCustomFields, err = app.getSuggestedCustomFields(ctx, doc, selectedIDs, docLogger)
+			suggestedCustomFields, err = app.getSuggestedCustomFields(ctx, doc, selectedIDs, docLogger, wfTemplate("custom_field_prompt", customFieldTemplate))
 			if err != nil {
 				log.Errorf("Error generating custom fields for document %d: %v", documentID, err)
 				return DocumentSuggestion{}, fmt.Errorf("Document %d: %v", documentID, err)

--- a/app_llm_test.go
+++ b/app_llm_test.go
@@ -570,7 +570,7 @@ func TestGetSuggestedCustomFields(t *testing.T) {
 
 	// 3. Execute
 	testLogger := logrus.WithField("test", "TestGetSuggestedCustomFields")
-	suggestions, err := app.getSuggestedCustomFields(context.Background(), doc, selectedFieldIDs, testLogger)
+	suggestions, err := app.getSuggestedCustomFields(context.Background(), doc, selectedFieldIDs, testLogger, nil)
 
 	// 4. Assert
 	require.NoError(t, err)

--- a/app_llm_test.go
+++ b/app_llm_test.go
@@ -157,7 +157,7 @@ Content: {{.Content}}
 
 			// Test with the app's LLM
 			ctx := context.Background()
-			_, err = app.getSuggestedTitle(ctx, truncatedContent, "Test Title", testLogger)
+			_, err = app.getSuggestedTitle(ctx, truncatedContent, "Test Title", testLogger, nil)
 			require.NoError(t, err)
 
 			// Verify truncation
@@ -210,7 +210,7 @@ func TestTokenLimitInCorrespondentGeneration(t *testing.T) {
 	availableCorrespondents := []string{"Test Corp", "Example Inc"}
 	correspondentBlackList := []string{"Blocked Corp"}
 
-	_, err := app.getSuggestedCorrespondent(ctx, longContent, "Test Title", availableCorrespondents, correspondentBlackList)
+	_, err := app.getSuggestedCorrespondent(ctx, longContent, "Test Title", availableCorrespondents, correspondentBlackList, nil)
 	require.NoError(t, err)
 
 	// Verify the final prompt size
@@ -248,7 +248,7 @@ func TestTokenLimitInTagGeneration(t *testing.T) {
 	availableTags := []string{"test", "example"}
 	originalTags := []string{"original"}
 
-	_, err := app.getSuggestedTags(ctx, longContent, "Test Title", availableTags, originalTags, testLogger)
+	_, err := app.getSuggestedTags(ctx, longContent, "Test Title", availableTags, originalTags, testLogger, nil)
 	require.NoError(t, err)
 
 	// Verify the final prompt size
@@ -281,7 +281,7 @@ func TestCreateNewTagsFiltering(t *testing.T) {
 		mockLLM := &mockLLM{Response: "invoice, new-tag, receipt"}
 		app := &App{LLM: mockLLM}
 
-		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger)
+		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger, nil)
 		require.NoError(t, err)
 
 		assert.Contains(t, tags, "invoice")
@@ -294,7 +294,7 @@ func TestCreateNewTagsFiltering(t *testing.T) {
 		mockLLM := &mockLLM{Response: "invoice, new-tag, receipt"}
 		app := &App{LLM: mockLLM}
 
-		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger)
+		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger, nil)
 		require.NoError(t, err)
 
 		assert.Contains(t, tags, "invoice")
@@ -307,7 +307,7 @@ func TestCreateNewTagsFiltering(t *testing.T) {
 		mockLLM := &mockLLM{Response: "Invoice, NEW-TAG"}
 		app := &App{LLM: mockLLM}
 
-		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger)
+		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger, nil)
 		require.NoError(t, err)
 
 		// Existing tag should use the available tag's casing
@@ -321,7 +321,7 @@ func TestCreateNewTagsFiltering(t *testing.T) {
 		mockLLM := &mockLLM{Response: "invoice, , receipt"}
 		app := &App{LLM: mockLLM}
 
-		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger)
+		tags, err := app.getSuggestedTags(ctx, "Some document content", "Test Invoice", availableTags, originalTags, testLogger, nil)
 		require.NoError(t, err)
 
 		for _, tag := range tags {
@@ -354,7 +354,7 @@ func TestTokenLimitInTitleGeneration(t *testing.T) {
 	// Call getSuggestedTitle
 	ctx := context.Background()
 
-	_, err := app.getSuggestedTitle(ctx, longContent, "Original Title", testLogger)
+	_, err := app.getSuggestedTitle(ctx, longContent, "Original Title", testLogger, nil)
 	require.NoError(t, err)
 
 	// Verify the final prompt size
@@ -390,7 +390,7 @@ func TestTokenLimitInCreatedDateGeneration(t *testing.T) {
 	// Call getSuggestedCreatedDate
 	ctx := context.Background()
 
-	_, err := app.getSuggestedCreatedDate(ctx, longContent, testLogger)
+	_, err := app.getSuggestedCreatedDate(ctx, longContent, testLogger, nil)
 	require.NoError(t, err)
 
 	// Verify the final prompt size

--- a/background.go
+++ b/background.go
@@ -198,22 +198,62 @@ func recoverFromFailedUpdate(ctx context.Context, client ClientInterface, db *go
 	}
 }
 
-// processAutoTagDocuments handles the background auto-tagging of documents
+// processAutoTagDocuments handles the background auto-tagging of documents.
+// It processes the global AUTO_TAG first, then iterates over all configured
+// named workflows, each identified by their own trigger tag.
 func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
-	documents, err := app.Client.GetDocumentsByTag(ctx, autoTag, 25)
+	totalProcessed := 0
+	var allErrs []error
+
+	// --- 1. Global AUTO_TAG (existing behaviour) ---
+	n, err := app.processTagDocuments(ctx, autoTag, "")
+	totalProcessed += n
 	if err != nil {
-		return 0, fmt.Errorf("error fetching documents with autoTag: %w", err)
+		allErrs = append(allErrs, err)
+	}
+
+	// --- 2. Named workflows ---
+	settingsMutex.RLock()
+	workflows := make([]WorkflowConfig, len(settings.Workflows))
+	copy(workflows, settings.Workflows)
+	settingsMutex.RUnlock()
+
+	for _, wf := range workflows {
+		if wf.TriggerTag == "" || wf.TriggerTag == autoTag {
+			continue // misconfigured or duplicate of global tag – skip
+		}
+		n, err := app.processTagDocuments(ctx, wf.TriggerTag, wf.ID)
+		totalProcessed += n
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return totalProcessed, errors.Join(allErrs...)
+	}
+	return totalProcessed, nil
+}
+
+// processTagDocuments fetches documents with the given tag and runs the
+// suggestion pipeline for each of them. workflowID, when non-empty, selects a
+// named workflow whose prompt overrides and generation flags are applied on top
+// of the global defaults.
+func (app *App) processTagDocuments(ctx context.Context, triggerTag string, workflowID string) (int, error) {
+	documents, err := app.Client.GetDocumentsByTag(ctx, triggerTag, 25)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching documents with tag %q: %w", triggerTag, err)
 	}
 
 	if len(documents) == 0 {
-		log.Debugf("No documents with tag %s found", autoTag)
+		log.Debugf("No documents with tag %s found", triggerTag)
 		return 0, nil // No documents to process
 	}
 
 	// Refresh the custom fields cache before processing, as we have documents
 	refreshCustomFieldsCache(app.Client)
 
-	log.Debugf("Found at least %d remaining documents with tag %s", len(documents), autoTag)
+	log.Debugf("Found at least %d remaining documents with tag %s", len(documents), triggerTag)
 
 	var errs []error
 	processedCount := 0
@@ -235,7 +275,11 @@ func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
 		}
 
 		docLogger := documentLogger(document.ID)
-		docLogger.Info("Processing document for auto-tagging")
+		if workflowID != "" {
+			docLogger.Infof("Processing document for workflow %q (trigger tag: %s)", workflowID, triggerTag)
+		} else {
+			docLogger.Info("Processing document for auto-tagging")
+		}
 
 		settingsMutex.RLock()
 		generateCustomFields := settings.CustomFieldsEnable
@@ -250,6 +294,7 @@ func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
 			GenerateCreatedDate:    strings.ToLower(autoGenerateCreatedDate) != "false",
 			GenerateCustomFields:   generateCustomFields,
 			IsAutoProcessing:       true,
+			WorkflowID:             workflowID,
 		}
 
 		suggestions, err := app.generateDocumentSuggestions(ctx, suggestionRequest, docLogger)
@@ -276,7 +321,7 @@ func (app *App) processAutoTagDocuments(ctx context.Context) (int, error) {
 			err = fmt.Errorf("error updating document %d: %w", document.ID, err)
 			docLogger.Error(err.Error())
 			errs = append(errs, err)
-			recoverFromFailedUpdate(ctx, app.Client, app.Database, document, autoTag)
+			recoverFromFailedUpdate(ctx, app.Client, app.Database, document, triggerTag)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -461,6 +461,12 @@ func main() {
 
 		// Get version information
 		api.GET("/version", getVersionHandler)
+
+		// Workflow CRUD
+		api.GET("/workflows", app.listWorkflowsHandler)
+		api.POST("/workflows", app.createWorkflowHandler)
+		api.PUT("/workflows/:id", app.updateWorkflowHandler)
+		api.DELETE("/workflows/:id", app.deleteWorkflowHandler)
 	}
 
 	// Serve frontend files
@@ -484,6 +490,9 @@ func main() {
 			c.File("web-app/dist/index.html")
 		})
 		router.GET("/adhoc-analysis", func(c *gin.Context) {
+			c.File("web-app/dist/index.html")
+		})
+		router.GET("/workflows", func(c *gin.Context) {
 			c.File("web-app/dist/index.html")
 		})
 		router.GET("/favicon.ico", func(c *gin.Context) {
@@ -522,6 +531,10 @@ func main() {
 		})
 		// adhoc-analysis route
 		router.GET("/adhoc-analysis", func(c *gin.Context) {
+			serveEmbeddedFile(c, "", "index.html")
+		})
+		// workflows route
+		router.GET("/workflows", func(c *gin.Context) {
 			serveEmbeddedFile(c, "", "index.html")
 		})
 	}

--- a/types.go
+++ b/types.go
@@ -98,6 +98,9 @@ type GenerateSuggestionsRequest struct {
 	GenerateCustomFields   bool       `json:"generate_custom_fields,omitempty"`
 	GenerateDocumentTypes  bool       `json:"generate_document_types,omitempty"`
 	IsAutoProcessing       bool       `json:"-"` // internal flag; not exposed via API
+	// WorkflowID, when set, selects a named workflow whose prompts and flags
+	// override the global defaults. Used by the background auto-tag processor.
+	WorkflowID string `json:"-"`
 }
 
 // AnalyzeDocumentsRequest is the request payload for the ad-hoc analysis
@@ -106,12 +109,36 @@ type AnalyzeDocumentsRequest struct {
 	Prompt      string `json:"prompt"`
 }
 
+// WorkflowConfig defines a named processing workflow triggered by a specific paperless-ngx tag.
+// Each workflow can override the global generation flags and carry its own prompt templates.
+type WorkflowConfig struct {
+	// ID is a stable, URL-safe identifier (e.g. "invoices"). Auto-generated when empty.
+	ID string `json:"id"`
+	// Name is a human-readable label shown in the UI.
+	Name string `json:"name"`
+	// TriggerTag is the paperless-ngx tag that activates this workflow (e.g. "paperless-gpt-invoices").
+	TriggerTag string `json:"trigger_tag"`
+	// CompletionTag is optionally added to a document after successful processing.
+	CompletionTag string `json:"completion_tag,omitempty"`
+	// Generation flags – nil means "inherit the global default".
+	GenerateTitles         *bool `json:"generate_titles,omitempty"`
+	GenerateTags           *bool `json:"generate_tags,omitempty"`
+	GenerateCorrespondents *bool `json:"generate_correspondents,omitempty"`
+	GenerateCreatedDate    *bool `json:"generate_created_date,omitempty"`
+	GenerateDocumentTypes  *bool `json:"generate_document_types,omitempty"`
+	GenerateCustomFields   *bool `json:"generate_custom_fields,omitempty"`
+	// Prompts maps prompt-file names (e.g. "title_prompt") to their template content.
+	// An absent key means the global default prompt is used.
+	Prompts map[string]string `json:"prompts,omitempty"`
+}
+
 // Settings defines the structure for server-side UI settings
 type Settings struct {
-	CustomFieldsEnable      bool        `json:"custom_fields_enable"`
-	CustomFieldsSelectedIDs []int       `json:"custom_fields_selected_ids"`
-	CustomFieldsWriteMode   string      `json:"custom_fields_write_mode"` // "append" or "replace"
-	OCR                     OCRDefaults `json:"ocr"`
+	CustomFieldsEnable      bool             `json:"custom_fields_enable"`
+	CustomFieldsSelectedIDs []int            `json:"custom_fields_selected_ids"`
+	CustomFieldsWriteMode   string           `json:"custom_fields_write_mode"` // "append" or "replace"
+	OCR                     OCRDefaults      `json:"ocr"`
+	Workflows               []WorkflowConfig `json:"workflows,omitempty"`
 }
 
 // OCRDefaults are persisted run-option defaults, editable from the UI.

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -6,6 +6,7 @@ import OCR from './OCR';
 import History from './History';
 import Settings from './components/Settings';
 import AdhocAnalysis from './AdhocAnalysis';
+import Workflows from './Workflows';
 
 const App: React.FC = () => {
   // Keep the base path (path prefix from reverse-proxy) and remove the app path,
@@ -27,6 +28,7 @@ const App: React.FC = () => {
             <Route path="/experimental-ocr" element={<Navigate to="/ocr" replace />} />
             <Route path="/history" element={<History />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/workflows" element={<Workflows />} />
           </Routes>
         </main>
       </div>

--- a/web-app/src/Workflows.tsx
+++ b/web-app/src/Workflows.tsx
@@ -1,0 +1,481 @@
+import {
+  PlusIcon,
+  TrashIcon,
+  PencilSquareIcon,
+  CheckIcon,
+  XMarkIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WorkflowConfig {
+  id: string;
+  name: string;
+  trigger_tag: string;
+  completion_tag?: string;
+  generate_titles?: boolean | null;
+  generate_tags?: boolean | null;
+  generate_correspondents?: boolean | null;
+  generate_created_date?: boolean | null;
+  generate_document_types?: boolean | null;
+  generate_custom_fields?: boolean | null;
+  prompts?: Record<string, string>;
+}
+
+const PROMPT_KEYS = [
+  { key: "title_prompt", label: "Title prompt" },
+  { key: "tag_prompt", label: "Tags prompt" },
+  { key: "correspondent_prompt", label: "Correspondent prompt" },
+  { key: "document_type_prompt", label: "Document type prompt" },
+  { key: "date_prompt", label: "Created date prompt" },
+];
+
+const FLAG_KEYS: { key: keyof WorkflowConfig; label: string }[] = [
+  { key: "generate_titles", label: "Generate title" },
+  { key: "generate_tags", label: "Generate tags" },
+  { key: "generate_correspondents", label: "Generate correspondent" },
+  { key: "generate_document_types", label: "Generate document type" },
+  { key: "generate_created_date", label: "Generate created date" },
+  { key: "generate_custom_fields", label: "Generate custom fields" },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyWorkflow = (): WorkflowConfig => ({
+  id: "",
+  name: "",
+  trigger_tag: "",
+  completion_tag: "",
+  prompts: {},
+});
+
+/** Tri-state flag selector: null = inherit global, true = enable, false = disable */
+const TriStateSelect: React.FC<{
+  value: boolean | null | undefined;
+  onChange: (v: boolean | null) => void;
+}> = ({ value, onChange }) => (
+  <select
+    value={value === null || value === undefined ? "inherit" : String(value)}
+    onChange={(e) => {
+      const v = e.target.value;
+      onChange(v === "inherit" ? null : v === "true");
+    }}
+    className="rounded border border-line bg-surface px-2 py-1 text-xs"
+  >
+    <option value="inherit">Inherit global</option>
+    <option value="true">Enabled</option>
+    <option value="false">Disabled</option>
+  </select>
+);
+
+// ---------------------------------------------------------------------------
+// WorkflowEditor
+// ---------------------------------------------------------------------------
+
+interface WorkflowEditorProps {
+  initial: WorkflowConfig;
+  onSave: (wf: WorkflowConfig) => void;
+  onCancel: () => void;
+  isNew: boolean;
+}
+
+const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
+  initial,
+  onSave,
+  onCancel,
+  isNew,
+}) => {
+  const [wf, setWf] = useState<WorkflowConfig>({ ...initial, prompts: { ...(initial.prompts ?? {}) } });
+  const [activePromptKey, setActivePromptKey] = useState<string>(PROMPT_KEYS[0].key);
+
+  const setFlag = (key: keyof WorkflowConfig, value: boolean | null) => {
+    setWf((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div className="space-y-6 rounded-lg border border-primary bg-surface p-6">
+      {/* Basic fields */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-muted">
+            Workflow name <span className="text-neg">*</span>
+          </label>
+          <input
+            className="w-full rounded border border-line bg-surface px-3 py-1.5 text-sm"
+            placeholder="e.g. Invoices"
+            value={wf.name}
+            onChange={(e) => setWf((p) => ({ ...p, name: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-muted">
+            Trigger tag <span className="text-neg">*</span>
+          </label>
+          <input
+            className="w-full rounded border border-line bg-surface px-3 py-1.5 text-sm font-mono"
+            placeholder="e.g. paperless-gpt-invoices"
+            value={wf.trigger_tag}
+            onChange={(e) => setWf((p) => ({ ...p, trigger_tag: e.target.value }))}
+          />
+          <p className="mt-1 text-xs text-faint">
+            Tag in paperless-ngx that activates this workflow.
+          </p>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-muted">
+            Completion tag (optional)
+          </label>
+          <input
+            className="w-full rounded border border-line bg-surface px-3 py-1.5 text-sm font-mono"
+            placeholder="e.g. paperless-gpt-invoices-done"
+            value={wf.completion_tag ?? ""}
+            onChange={(e) => setWf((p) => ({ ...p, completion_tag: e.target.value }))}
+          />
+          <p className="mt-1 text-xs text-faint">
+            Added to the document after successful processing.
+          </p>
+        </div>
+        {!isNew && (
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted">
+              Workflow ID
+            </label>
+            <input
+              className="w-full rounded border border-line bg-surface-2 px-3 py-1.5 text-sm font-mono text-faint"
+              value={wf.id}
+              readOnly
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Generation flags */}
+      <div>
+        <h3 className="mb-3 text-sm font-semibold">Generation flags</h3>
+        <div className="flex flex-wrap gap-4">
+          {FLAG_KEYS.map(({ key, label }) => (
+            <div key={key} className="flex flex-col gap-1">
+              <span className="text-xs text-muted">{label}</span>
+              <TriStateSelect
+                value={wf[key] as boolean | null}
+                onChange={(v) => setFlag(key, v)}
+              />
+            </div>
+          ))}
+        </div>
+        <p className="mt-2 flex items-center gap-1 text-xs text-faint">
+          <InformationCircleIcon className="h-4 w-4 shrink-0" />
+          "Inherit global" uses the server's AUTO_GENERATE_* environment variables.
+        </p>
+      </div>
+
+      {/* Per-workflow prompts */}
+      <div>
+        <h3 className="mb-3 text-sm font-semibold">Custom prompts</h3>
+        <p className="mb-3 text-xs text-faint">
+          Leave a prompt empty to use the global default from Settings → Prompts.
+        </p>
+        <div className="flex gap-2 flex-wrap mb-3">
+          {PROMPT_KEYS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setActivePromptKey(key)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                activePromptKey === key
+                  ? "bg-primary-tint text-ink"
+                  : "bg-surface-2 text-muted hover:text-ink"
+              } ${wf.prompts?.[key] ? "ring-1 ring-primary" : ""}`}
+            >
+              {label}
+              {wf.prompts?.[key] ? " •" : ""}
+            </button>
+          ))}
+        </div>
+        <textarea
+          className="w-full rounded border border-line bg-surface px-3 py-2 font-mono text-xs"
+          rows={10}
+          placeholder={`Leave empty to use the global ${activePromptKey} template…`}
+          value={wf.prompts?.[activePromptKey] ?? ""}
+          onChange={(e) =>
+            setWf((p) => ({
+              ...p,
+              prompts: { ...(p.prompts ?? {}), [activePromptKey]: e.target.value },
+            }))
+          }
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex h-9 items-center gap-2 rounded-md border border-line px-4 text-sm text-muted hover:bg-surface-2"
+        >
+          <XMarkIcon className="h-4 w-4" /> Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => onSave(wf)}
+          className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark"
+        >
+          <CheckIcon className="h-4 w-4" /> Save workflow
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// WorkflowCard
+// ---------------------------------------------------------------------------
+
+const WorkflowCard: React.FC<{
+  wf: WorkflowConfig;
+  onEdit: () => void;
+  onDelete: () => void;
+}> = ({ wf, onEdit, onDelete }) => {
+  const overriddenFlags = FLAG_KEYS.filter(({ key }) => wf[key] !== null && wf[key] !== undefined);
+  const overriddenPrompts = Object.keys(wf.prompts ?? {}).filter(
+    (k) => (wf.prompts ?? {})[k]?.trim()
+  );
+
+  return (
+    <div className="rounded-lg border border-line bg-surface p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h3 className="truncate font-semibold">{wf.name || wf.id}</h3>
+          <p className="mt-0.5 font-mono text-xs text-muted">
+            Trigger: <span className="text-ink">{wf.trigger_tag}</span>
+            {wf.completion_tag && (
+              <>
+                {" "}→{" "}
+                <span className="text-ink">{wf.completion_tag}</span>
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={onEdit}
+            className="rounded-md p-1.5 text-muted hover:bg-surface-2 hover:text-ink"
+            title="Edit"
+          >
+            <PencilSquareIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="rounded-md p-1.5 text-muted hover:bg-surface-2 hover:text-neg"
+            title="Delete"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      {(overriddenFlags.length > 0 || overriddenPrompts.length > 0) && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {overriddenFlags.map(({ key, label }) => (
+            <span
+              key={key}
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                wf[key] ? "bg-pos-tint text-pos-ink" : "bg-neg-tint text-neg-ink"
+              }`}
+            >
+              {wf[key] ? "✓" : "✗"} {label}
+            </span>
+          ))}
+          {overriddenPrompts.map((k) => (
+            <span
+              key={k}
+              className="inline-flex items-center rounded-full bg-primary-tint px-2 py-0.5 text-xs font-medium text-ink"
+            >
+              Custom: {PROMPT_KEYS.find((p) => p.key === k)?.label ?? k}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Workflows page
+// ---------------------------------------------------------------------------
+
+const Workflows: React.FC = () => {
+  const [workflows, setWorkflows] = useState<WorkflowConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null); // null = none, "new" = creating
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  const fetchWorkflows = async () => {
+    try {
+      const res = await axios.get<WorkflowConfig[]>("./api/workflows");
+      setWorkflows(res.data ?? []);
+    } catch (e: unknown) {
+      setError((e as Error).message ?? "Failed to load workflows");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWorkflows();
+  }, []);
+
+  const handleSave = async (wf: WorkflowConfig) => {
+    try {
+      if (editingId === "new") {
+        const res = await axios.post<WorkflowConfig>("./api/workflows", wf);
+        setWorkflows((prev) => [...prev, res.data]);
+      } else {
+        const res = await axios.put<WorkflowConfig>(`./api/workflows/${wf.id}`, wf);
+        setWorkflows((prev) => prev.map((w) => (w.id === wf.id ? res.data : w)));
+      }
+      setEditingId(null);
+    } catch (e: unknown) {
+      const msg =
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        (e as Error).message ??
+        "Failed to save workflow";
+      setError(msg);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await axios.delete(`./api/workflows/${id}`);
+      setWorkflows((prev) => prev.filter((w) => w.id !== id));
+      setDeleteConfirmId(null);
+    } catch (e: unknown) {
+      setError((e as Error).message ?? "Failed to delete workflow");
+    }
+  };
+
+  const editingWorkflow =
+    editingId === "new"
+      ? emptyWorkflow()
+      : workflows.find((w) => w.id === editingId) ?? null;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:px-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Workflows</h1>
+          <p className="mt-1 text-sm text-muted">
+            Each workflow watches a specific paperless-ngx tag and applies its own
+            prompts and generation settings.
+          </p>
+        </div>
+        {editingId === null && (
+          <button
+            type="button"
+            onClick={() => setEditingId("new")}
+            className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark"
+          >
+            <PlusIcon className="h-4 w-4" /> New workflow
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-neg-line bg-neg-tint px-4 py-3 text-sm text-neg-ink">
+          {error}
+          <button
+            type="button"
+            className="ml-2 underline"
+            onClick={() => setError(null)}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* New / edit form */}
+      {editingId !== null && editingWorkflow !== null && (
+        <WorkflowEditor
+          key={editingId}
+          initial={editingWorkflow}
+          isNew={editingId === "new"}
+          onSave={handleSave}
+          onCancel={() => setEditingId(null)}
+        />
+      )}
+
+      {/* List */}
+      {loading ? (
+        <p className="text-sm text-muted">Loading…</p>
+      ) : workflows.length === 0 && editingId === null ? (
+        <div className="rounded-lg border border-dashed border-line p-10 text-center">
+          <p className="text-sm text-muted">No workflows configured yet.</p>
+          <p className="mt-1 text-xs text-faint">
+            Create one to process documents with a custom prompt and settings.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {workflows.map((wf) =>
+            editingId === wf.id ? null : (
+              <div key={wf.id}>
+                {deleteConfirmId === wf.id ? (
+                  <div className="rounded-lg border border-neg-line bg-neg-tint p-4 text-sm">
+                    <p className="font-medium text-neg-ink">
+                      Delete workflow "{wf.name || wf.id}"?
+                    </p>
+                    <p className="mt-1 text-xs text-faint">
+                      Documents tagged with{" "}
+                      <span className="font-mono">{wf.trigger_tag}</span> will fall
+                      back to the global AUTO_TAG behaviour (if that tag is also
+                      configured).
+                    </p>
+                    <div className="mt-3 flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(wf.id)}
+                        className="inline-flex h-8 items-center gap-1 rounded-md bg-neg px-3 text-xs font-medium text-white hover:bg-neg-dark"
+                      >
+                        <TrashIcon className="h-3.5 w-3.5" /> Delete
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteConfirmId(null)}
+                        className="inline-flex h-8 items-center rounded-md border border-line px-3 text-xs text-muted hover:bg-surface-2"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <WorkflowCard
+                    wf={wf}
+                    onEdit={() => {
+                      setEditingId(wf.id);
+                      setDeleteConfirmId(null);
+                    }}
+                    onDelete={() => {
+                      setDeleteConfirmId(wf.id);
+                      setEditingId(null);
+                    }}
+                  />
+                )}
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Workflows;

--- a/web-app/src/Workflows.tsx
+++ b/web-app/src/Workflows.tsx
@@ -2,6 +2,8 @@ import {
   PlusIcon,
   TrashIcon,
   PencilSquareIcon,
+  DocumentDuplicateIcon,
+  MagnifyingGlassIcon,
   CheckIcon,
   XMarkIcon,
   InformationCircleIcon,
@@ -56,6 +58,20 @@ const emptyWorkflow = (): WorkflowConfig => ({
   completion_tag: "",
   prompts: {},
 });
+
+const hasCustomPrompt = (wf: WorkflowConfig): boolean =>
+  Object.values(wf.prompts ?? {}).some((p) => !!p?.trim());
+
+/** Deep-copy a workflow for create-from-duplicate; clears id and trigger_tag. */
+const cloneWorkflowForDuplicate = (wf: WorkflowConfig): WorkflowConfig => ({
+  ...wf,
+  id: "",
+  name: wf.name ? `${wf.name} (copy)` : "",
+  trigger_tag: "",
+  prompts: { ...(wf.prompts ?? {}) },
+});
+
+type PromptFilter = "all" | "custom" | "default";
 
 /** Tri-state flag selector: null = inherit global, true = enable, false = disable */
 const TriStateSelect: React.FC<{
@@ -242,8 +258,9 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
 const WorkflowCard: React.FC<{
   wf: WorkflowConfig;
   onEdit: () => void;
+  onDuplicate: () => void;
   onDelete: () => void;
-}> = ({ wf, onEdit, onDelete }) => {
+}> = ({ wf, onEdit, onDuplicate, onDelete }) => {
   const overriddenFlags = FLAG_KEYS.filter(({ key }) => wf[key] !== null && wf[key] !== undefined);
   const overriddenPrompts = Object.keys(wf.prompts ?? {}).filter(
     (k) => (wf.prompts ?? {})[k]?.trim()
@@ -272,6 +289,14 @@ const WorkflowCard: React.FC<{
             title="Edit"
           >
             <PencilSquareIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onDuplicate}
+            className="rounded-md p-1.5 text-muted hover:bg-surface-2 hover:text-ink"
+            title="Duplicate"
+          >
+            <DocumentDuplicateIcon className="h-4 w-4" />
           </button>
           <button
             type="button"
@@ -318,7 +343,11 @@ const Workflows: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null); // null = none, "new" = creating
+  const [draft, setDraft] = useState<WorkflowConfig | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [promptFilter, setPromptFilter] = useState<PromptFilter>("all");
 
   const fetchWorkflows = async () => {
     try {
@@ -335,6 +364,18 @@ const Workflows: React.FC = () => {
     fetchWorkflows();
   }, []);
 
+  const openNew = (initial: WorkflowConfig = emptyWorkflow()) => {
+    setDraft(initial);
+    setEditorKey((k) => k + 1);
+    setEditingId("new");
+    setDeleteConfirmId(null);
+  };
+
+  const closeEditor = () => {
+    setEditingId(null);
+    setDraft(null);
+  };
+
   const handleSave = async (wf: WorkflowConfig) => {
     try {
       if (editingId === "new") {
@@ -344,7 +385,7 @@ const Workflows: React.FC = () => {
         const res = await axios.put<WorkflowConfig>(`./api/workflows/${wf.id}`, wf);
         setWorkflows((prev) => prev.map((w) => (w.id === wf.id ? res.data : w)));
       }
-      setEditingId(null);
+      closeEditor();
     } catch (e: unknown) {
       const msg =
         (e as { response?: { data?: { error?: string } } })?.response?.data?.error ??
@@ -364,10 +405,25 @@ const Workflows: React.FC = () => {
     }
   };
 
+  const filteredWorkflows = (() => {
+    const q = query.trim().toLowerCase();
+    return workflows.filter((wf) => {
+      if (q) {
+        const haystack = `${wf.name} ${wf.trigger_tag} ${wf.id}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      if (promptFilter === "custom" && !hasCustomPrompt(wf)) return false;
+      if (promptFilter === "default" && hasCustomPrompt(wf)) return false;
+      return true;
+    });
+  })();
+
   const editingWorkflow =
     editingId === "new"
-      ? emptyWorkflow()
+      ? (draft ?? emptyWorkflow())
       : workflows.find((w) => w.id === editingId) ?? null;
+
+  const filtersActive = query.trim() !== "" || promptFilter !== "all";
 
   return (
     <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:px-6">
@@ -382,7 +438,7 @@ const Workflows: React.FC = () => {
         {editingId === null && (
           <button
             type="button"
-            onClick={() => setEditingId("new")}
+            onClick={() => openNew()}
             className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark"
           >
             <PlusIcon className="h-4 w-4" /> New workflow
@@ -406,12 +462,42 @@ const Workflows: React.FC = () => {
       {/* New / edit form */}
       {editingId !== null && editingWorkflow !== null && (
         <WorkflowEditor
-          key={editingId}
+          key={editorKey || editingId}
           initial={editingWorkflow}
           isNew={editingId === "new"}
           onSave={handleSave}
-          onCancel={() => setEditingId(null)}
+          onCancel={closeEditor}
         />
+      )}
+
+      {/* Filters */}
+      {!loading && workflows.length > 0 && editingId === null && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="relative min-w-0 flex-1">
+            <MagnifyingGlassIcon
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-faint"
+              aria-hidden="true"
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter by name or trigger tag…"
+              aria-label="Filter workflows by name or trigger"
+              className="h-9 w-full rounded-md border border-line bg-surface pl-9 pr-3 text-sm"
+            />
+          </div>
+          <select
+            value={promptFilter}
+            onChange={(e) => setPromptFilter(e.target.value as PromptFilter)}
+            aria-label="Filter by custom prompts"
+            className="h-9 rounded-md border border-line bg-surface px-3 text-sm"
+          >
+            <option value="all">All prompts</option>
+            <option value="custom">Has custom prompt</option>
+            <option value="default">No custom prompt</option>
+          </select>
+        </div>
       )}
 
       {/* List */}
@@ -424,9 +510,14 @@ const Workflows: React.FC = () => {
             Create one to process documents with a custom prompt and settings.
           </p>
         </div>
+      ) : filteredWorkflows.length === 0 && editingId === null ? (
+        <p className="text-sm text-muted">
+          No workflows match
+          {filtersActive ? " the current filters" : ""}.
+        </p>
       ) : (
         <div className="space-y-4">
-          {workflows.map((wf) =>
+          {filteredWorkflows.map((wf) =>
             editingId === wf.id ? null : (
               <div key={wf.id}>
                 {deleteConfirmId === wf.id ? (
@@ -462,11 +553,14 @@ const Workflows: React.FC = () => {
                     wf={wf}
                     onEdit={() => {
                       setEditingId(wf.id);
+                      setDraft(null);
                       setDeleteConfirmId(null);
                     }}
+                    onDuplicate={() => openNew(cloneWorkflowForDuplicate(wf))}
                     onDelete={() => {
                       setDeleteConfirmId(wf.id);
                       setEditingId(null);
+                      setDraft(null);
                     }}
                   />
                 )}

--- a/web-app/src/Workflows.tsx
+++ b/web-app/src/Workflows.tsx
@@ -33,6 +33,7 @@ const PROMPT_KEYS = [
   { key: "correspondent_prompt", label: "Correspondent prompt" },
   { key: "document_type_prompt", label: "Document type prompt" },
   { key: "date_prompt", label: "Created date prompt" },
+  { key: "custom_field_prompt", label: "Custom fields prompt" },
 ];
 
 const FLAG_KEYS: { key: keyof WorkflowConfig; label: string }[] = [

--- a/web-app/src/components/Sidebar.tsx
+++ b/web-app/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   DocumentMagnifyingGlassIcon,
   HomeIcon,
   Bars3Icon,
+  QueueListIcon,
 } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import React, { useEffect, useState } from "react";
@@ -63,6 +64,12 @@ const Sidebar: React.FC = () => {
       title: "Ad-hoc Analysis",
     },
     { name: "history", path: "./history", icon: ClockIcon, title: "History" },
+    {
+      name: "workflows",
+      path: "./workflows",
+      icon: QueueListIcon,
+      title: "Workflows",
+    },
     {
       name: "settings",
       path: "./settings",

--- a/workflow_prompts.go
+++ b/workflow_prompts.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+// workflowTemplateCache caches compiled per-workflow templates so they are not
+// re-parsed on every document. The cache is invalidated whenever a workflow is
+// saved via the API.
+var (
+	workflowTemplateCacheMu sync.RWMutex
+	workflowTemplateCache   = map[string]map[string]*template.Template{} // workflowID → promptName → template
+)
+
+// invalidateWorkflowTemplateCache drops all cached templates for a specific
+// workflow (or all workflows when id is "").
+func invalidateWorkflowTemplateCache(id string) {
+	workflowTemplateCacheMu.Lock()
+	defer workflowTemplateCacheMu.Unlock()
+	if id == "" {
+		workflowTemplateCache = map[string]map[string]*template.Template{}
+	} else {
+		delete(workflowTemplateCache, id)
+	}
+}
+
+// getWorkflowTemplate returns the compiled template for a workflow + prompt
+// name. Falls back to the global template when the workflow has no override.
+// globalTmpl must be non-nil.
+func getWorkflowTemplate(wf WorkflowConfig, promptName string, globalTmpl *template.Template) (*template.Template, error) {
+	raw, hasOverride := wf.Prompts[promptName]
+	if !hasOverride || strings.TrimSpace(raw) == "" {
+		return globalTmpl, nil
+	}
+
+	// Try cache first.
+	workflowTemplateCacheMu.RLock()
+	if byName, ok := workflowTemplateCache[wf.ID]; ok {
+		if tmpl, ok := byName[promptName]; ok {
+			workflowTemplateCacheMu.RUnlock()
+			return tmpl, nil
+		}
+	}
+	workflowTemplateCacheMu.RUnlock()
+
+	// Parse and cache.
+	tmpl, err := template.New(promptName).Funcs(sprig.FuncMap()).Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("workflow %q: invalid template for %q: %w", wf.ID, promptName, err)
+	}
+
+	workflowTemplateCacheMu.Lock()
+	if workflowTemplateCache[wf.ID] == nil {
+		workflowTemplateCache[wf.ID] = map[string]*template.Template{}
+	}
+	workflowTemplateCache[wf.ID][promptName] = tmpl
+	workflowTemplateCacheMu.Unlock()
+
+	return tmpl, nil
+}
+
+// executeWorkflowTemplate is a helper that executes a (possibly workflow-
+// overridden) template against templateData and returns the rendered prompt.
+func executeWorkflowTemplate(tmpl *template.Template, data map[string]interface{}) (string, error) {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// getWorkflowByID looks up a workflow by its ID in the current settings. It
+// returns a zero-value WorkflowConfig and false when not found.
+func getWorkflowByID(id string) (WorkflowConfig, bool) {
+	if id == "" {
+		return WorkflowConfig{}, false
+	}
+	settingsMutex.RLock()
+	defer settingsMutex.RUnlock()
+	for _, wf := range settings.Workflows {
+		if wf.ID == id {
+			return wf, true
+		}
+	}
+	return WorkflowConfig{}, false
+}
+
+// resolveGenerationFlags returns a GenerateSuggestionsRequest whose bool flags
+// are resolved from the workflow overrides (if any) on top of the global
+// defaults encoded in the base request.
+func resolveGenerationFlags(base GenerateSuggestionsRequest, wf WorkflowConfig) GenerateSuggestionsRequest {
+	r := base
+	if wf.GenerateTitles != nil {
+		r.GenerateTitles = *wf.GenerateTitles
+	}
+	if wf.GenerateTags != nil {
+		r.GenerateTags = *wf.GenerateTags
+	}
+	if wf.GenerateCorrespondents != nil {
+		r.GenerateCorrespondents = *wf.GenerateCorrespondents
+	}
+	if wf.GenerateCreatedDate != nil {
+		r.GenerateCreatedDate = *wf.GenerateCreatedDate
+	}
+	if wf.GenerateDocumentTypes != nil {
+		r.GenerateDocumentTypes = *wf.GenerateDocumentTypes
+	}
+	if wf.GenerateCustomFields != nil {
+		r.GenerateCustomFields = *wf.GenerateCustomFields
+	}
+	return r
+}


### PR DESCRIPTION
## Summary
- Add a Duplicate action that opens the create editor with flags, prompts, and completion tag copied (id and trigger tag cleared so the unique-tag check applies).
- Add client-side list filters: text search over name/trigger, plus All / Has custom prompt / No custom prompt.

## Test plan
- [ ] Duplicate an existing workflow — editor shows (copy) name, empty trigger, retained prompts/flags
- [ ] Saving without changing trigger_tag fails with conflict; with a new tag succeeds
- [ ] Filter by name/trigger narrows the list
- [ ] Has custom prompt / No custom prompt filters match correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow management through the new Workflows page.
  * Create, edit, duplicate, search, filter, and delete workflows with configurable trigger and completion tags.
  * Configure per-workflow generation options and custom prompts.
  * Added workflow-specific REST API support.
* **Enhancements**
  * Automatic document processing now supports multiple named workflows.
  * Completed workflows update document tags by removing the trigger tag and adding the completion tag.
  * Workflow-specific settings can override global generation preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->