### PR TITLE
docs: explain the OpenAI-compatible endpoint pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ https://github.com/user-attachments/assets/bd5d38b9-9309-40b9-93ca-918dfa4f3fd4
     - [Usage Recommendations](#usage-recommendations)
   - [Configuration](#configuration)
     - [Environment Variables](#environment-variables)
+    - [Using a Different AI Provider](#using-a-different-ai-provider)
     - [Custom Prompt Templates](#custom-prompt-templates)
       - [Template Variables](#template-variables)
   - [LLM-Based OCR: Compare for Yourself](#llm-based-ocr-compare-for-yourself)
@@ -572,7 +573,7 @@ For best results with the enhanced OCR features:
 | `MISTRAL_API_KEY`                   | Mistral API key (required if using Mistral).                                                                                                                                                  | Cond.    |                            |
 | `ANTHROPIC_API_KEY`                 | Anthropic API key (required if using Anthropic/Claude).                                                                                                                                       | Cond.    |                            |
 | `OPENAI_API_TYPE`                   | Set to `azure` to use Azure OpenAI Service.                                                                                                                                                   | No       |                            |
-| `OPENAI_BASE_URL`                   | Base URL for OpenAI API. Use it to point to an OpenAI-compatible endpoint (e.g. OpenRouter, LiteLLM, vLLM). For Azure OpenAI, set to your deployment URL (e.g., `https://your-resource.openai.azure.com`). | No       |                            |
+| `OPENAI_BASE_URL`                   | Base URL for OpenAI API. Use it to point to any OpenAI-compatible endpoint (OpenRouter, LM Studio, vLLM, LiteLLM, llama.cpp, Groq, …) — see [OpenAI-compatible providers](docs/openai_compatible_providers.md) for ready-made configurations. For Azure OpenAI, set to your deployment URL (e.g., `https://your-resource.openai.azure.com`). | No       |                            |
 | `LLM_LANGUAGE`                      | Likely language for documents (e.g. `English`). Appears in the prompt to help the LLM.                                                                                                                                               | No       | English                    |
 | `GOOGLEAI_API_KEY`                  | Google Gemini API key (required if using `LLM_PROVIDER=googleai`).                                                                                                                            | Cond.    |                            |
 | `GOOGLEAI_THINKING_BUDGET`          | (Optional, googleai only) Integer. Controls Gemini "thinking" budget. If unset, model default is used (thinking enabled if supported). Set to `0` to disable thinking (if model supports it). | No       |                            |
@@ -640,6 +641,33 @@ For best results with the enhanced OCR features:
 
 > [!NOTE]
 > `PDF_UPLOAD`, `PDF_REPLACE`, `PDF_COPY_METADATA`, `OCR_LIMIT_PAGES` and `OCR_PROCESS_MODE` act as *defaults*. The OCR Playground can override them per run, and "Save as defaults" in the UI persists tuned values to `config/settings.json`, which then takes precedence for Auto-OCR and future runs. The **Active Configuration** panel on the Settings page shows each value's effective source (env / saved / default).
+
+### Using a Different AI Provider
+
+`LLM_PROVIDER` accepts `openai`, `ollama`, `googleai`, `mistral` and
+`anthropic`. That list is shorter than it looks: **any service that speaks the
+OpenAI chat-completions API works via `LLM_PROVIDER=openai` plus
+`OPENAI_BASE_URL`**, without a code change or a new release.
+
+```yaml
+environment:
+  LLM_PROVIDER: "openai"
+  OPENAI_BASE_URL: "https://openrouter.ai/api/v1" # any compatible endpoint
+  OPENAI_API_KEY: "<that vendor's key>"
+  LLM_MODEL: "<a model name that vendor accepts>"
+```
+
+This covers OpenRouter, LM Studio, vLLM, LiteLLM, llama.cpp, Groq, Together,
+Azure OpenAI and most other hosted or self-hosted gateways.
+
+See **[OpenAI-compatible providers](docs/openai_compatible_providers.md)** for
+copy-pasteable configurations per service, plus fixes for the common errors
+(`404 model not found`, `413`, SSE decode failures, `temperature` rejections).
+
+> [!TIP]
+> For Ollama, prefer the native `LLM_PROVIDER=ollama` over its OpenAI shim — the
+> native path exposes `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_THINK`, which the shim
+> does not.
 
 ### Custom Prompt Templates
 

--- a/docs/openai_compatible_providers.md
+++ b/docs/openai_compatible_providers.md
@@ -1,0 +1,153 @@
+# OpenAI-compatible providers
+
+paperless-gpt does not need a dedicated code path for every AI vendor. Any
+service that speaks the OpenAI chat-completions API works today with
+`LLM_PROVIDER=openai` and `OPENAI_BASE_URL` pointed at it — no new release, no
+patch, no fork.
+
+If you came here from an issue asking for "support for X", this is almost
+certainly the answer.
+
+## The pattern
+
+```yaml
+environment:
+  LLM_PROVIDER: "openai"
+  OPENAI_BASE_URL: "https://api.example.com/v1" # the vendor's endpoint
+  OPENAI_API_KEY: "<your key for that vendor>"
+  LLM_MODEL: "<a model name that vendor accepts>"
+```
+
+Three things to get right:
+
+1. **`OPENAI_BASE_URL` must point at the API root that serves
+   `/chat/completions`**, not at the vendor's homepage or docs. For most
+   services that means the URL ends in `/v1`.
+2. **`LLM_MODEL` must be a name the vendor recognises**, which is often not the
+   same string OpenAI uses. Check the vendor's model list.
+3. **`OPENAI_API_KEY` holds the vendor's key.** The variable is named after the
+   protocol, not the company — you are not sending anything to OpenAI.
+
+The same applies to vision/OCR with `VISION_LLM_PROVIDER=openai` and
+`VISION_LLM_MODEL`, provided the endpoint supports image inputs. Many
+text-only gateways do not.
+
+## Verified configurations
+
+These have been reported working by users. Model names change often, so treat
+them as starting points rather than guarantees.
+
+### OpenRouter
+
+```yaml
+LLM_PROVIDER: "openai"
+OPENAI_BASE_URL: "https://openrouter.ai/api/v1"
+OPENAI_API_KEY: "sk-or-..."
+LLM_MODEL: "anthropic/claude-sonnet-4-5"
+```
+
+### LM Studio
+
+Enable the local server in LM Studio, then:
+
+```yaml
+LLM_PROVIDER: "openai"
+OPENAI_BASE_URL: "http://host.docker.internal:1234/v1"
+OPENAI_API_KEY: "lm-studio" # any non-empty value; LM Studio ignores it
+LLM_MODEL: "<the model identifier shown in LM Studio>"
+```
+
+### vLLM
+
+```yaml
+LLM_PROVIDER: "openai"
+OPENAI_BASE_URL: "http://vllm:8000/v1"
+OPENAI_API_KEY: "not-used" # any non-empty value unless you configured a key
+LLM_MODEL: "<the model you served with --model>"
+```
+
+### LiteLLM proxy
+
+```yaml
+LLM_PROVIDER: "openai"
+OPENAI_BASE_URL: "http://litellm:4000/v1"
+OPENAI_API_KEY: "<your LiteLLM virtual key>"
+LLM_MODEL: "<the model alias configured in LiteLLM>"
+```
+
+### llama.cpp server
+
+```yaml
+LLM_PROVIDER: "openai"
+OPENAI_BASE_URL: "http://llamacpp:8080/v1"
+OPENAI_API_KEY: "not-used"
+LLM_MODEL: "<any string; llama.cpp serves the model it was started with>"
+```
+
+### Azure OpenAI
+
+Azure is the one case with its own switch, because the URL layout and auth
+differ:
+
+```yaml
+LLM_PROVIDER: "openai"
+OPENAI_API_TYPE: "azure"
+OPENAI_BASE_URL: "https://your-resource.openai.azure.com"
+OPENAI_API_KEY: "<your Azure key>"
+LLM_MODEL: "<your deployment name>"
+```
+
+Note that `LLM_MODEL` is the **deployment** name, not the base model name.
+
+### Other services
+
+Anything else that documents an "OpenAI-compatible endpoint" — Groq, Together,
+DeepInfra, Fireworks, Atlas Cloud, Chatanywhere, 1min.ai, Docker Model Runner,
+Ollama's own `/v1` shim, and so on — follows the same three-line pattern. If a
+service documents an OpenAI-compatible base URL, it works here.
+
+## When to use the native Ollama provider instead
+
+For Ollama, prefer `LLM_PROVIDER=ollama` with `OLLAMA_HOST` over its
+OpenAI-compatible shim. The native path supports settings the shim does not
+expose, including `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_THINK`. Use the shim only
+if you have a specific reason to.
+
+## Troubleshooting
+
+**`invalid character 'd' looking for beginning of value`**
+The gateway answered with a server-sent-events stream while a plain JSON
+response was expected — the `d` is the first byte of a `data:` frame. Some
+gateways treat a missing `stream` field as "streaming on". See #1035.
+
+**`404 page not found` or `404 model not found`**
+Usually `OPENAI_BASE_URL` is missing the `/v1` suffix, or `LLM_MODEL` uses
+OpenAI's spelling of a model the vendor names differently.
+
+**`401 Unauthorized` from a local server**
+Most local servers require the key to be non-empty even though they ignore its
+value. Set it to any placeholder string.
+
+**`API returned unexpected status code: 413`**
+The request body exceeded the endpoint's limit. This is common in OCR mode with
+high-resolution scans; lower `OCR_LIMIT_PAGES`, or raise the proxy's body-size
+limit (`client_max_body_size` in nginx). See #791.
+
+**`400 Unsupported value: 'temperature'`**
+The model rejects the temperature being sent. Set `VISION_LLM_TEMPERATURE` (or
+the equivalent for your path) to a value the model accepts — for OpenAI's GPT-5
+family that is `1.0`. See #862 and #1003.
+
+## Why there is no per-vendor setting
+
+A dedicated `LLM_PROVIDER` value per vendor would add a code branch, an
+environment variable, a required-key check and several provider lists to keep in
+sync — for each vendor, permanently — while doing exactly what the two lines
+above already do. Worse, hand-rolled branches tend to omit capabilities the
+shared OpenAI path already has, such as the Azure handling and the base-URL
+override.
+
+A vendor genuinely needs its own provider only when the OpenAI-compatible shape
+cannot express it: non-standard authentication headers, a different request
+body, or endpoints that are not `/v1/chat/completions`. If you hit that, open an
+issue with the failing request and response.


### PR DESCRIPTION
> 🤖 **Automated change** — written by Claude Code running in the maintainer's repo checkout and pushed under the maintainer's account, not hand-written by them.

Addresses #864, #903, #908, #1041 and #830, and gives #979 and #1042 an answer that doesn't require merging per-vendor code.

## Why

Six open issues request AI providers that **already work today**:

| Issue | Request | Already works via |
|---|---|---|
| #864 | 1min.ai | `OPENAI_BASE_URL` |
| #903 | GitHub Copilot | `OPENAI_BASE_URL` |
| #908 | LM Studio | `OPENAI_BASE_URL` |
| #1041 | Atlas Cloud | `OPENAI_BASE_URL` |
| #830 | Tongyi / Chatanywhere | `OPENAI_BASE_URL` |
| #979 | OpenRouter | `OPENAI_BASE_URL` |

Six people asking for something that ships is a documentation failure, not six missing features. `OPENAI_BASE_URL` appeared in exactly one place — a row in a 100-row environment-variable table — so nobody scanning for "does it support X" ever found it.

The cost of that gap isn't just support load. #1042 arrived as a PR adding an `atlas` branch to `createLLM()`: a new `case`, a new env var, a new required-key check and four provider lists to keep in sync, all to do what two existing settings already do. It was also *strictly less capable* than the path it duplicated, having dropped the `OPENAI_API_TYPE`/Azure handling and the `OPENAI_BASE_URL` override. Merging one such branch makes it hard to refuse the other five, and then every OpenAI-compatible vendor has its own permanent code path doing the same thing.

## What this adds

`docs/openai_compatible_providers.md`:

- The three-line pattern, stated up front.
- The three things people get wrong: base URL missing `/v1`, `LLM_MODEL` using OpenAI's spelling of a model the vendor names differently, and local servers rejecting an empty API key even though they ignore its value.
- Copy-pasteable configs for OpenRouter, LM Studio, vLLM, LiteLLM, llama.cpp and Azure OpenAI (including the "`LLM_MODEL` is the deployment name" gotcha).
- A troubleshooting section mapping recurring error messages to causes: the SSE decode failure from #1035, the 413 from #791, and the `temperature` rejections from #862 / #1003.
- The rationale for not adding per-vendor branches, and the criteria under which a vendor *would* genuinely need one (non-standard auth, different request body, non-`/v1/chat/completions` endpoints).

Plus a **Using a Different AI Provider** section in the README with the pattern inline, TOC entry, and a rewritten `OPENAI_BASE_URL` table row that points at the guide.

One correctness note worth flagging: the guide tells Ollama users to prefer the native `LLM_PROVIDER=ollama` over Ollama's own OpenAI shim, because the shim exposes neither `OLLAMA_CONTEXT_LENGTH` nor `OLLAMA_THINK` — the latter being the subject of #1024 and #1056.

## Verification

Docs-only; no code paths touched. Every configuration listed reflects what `createLLM()` in `main.go` actually does with `OPENAI_BASE_URL`, `OPENAI_API_TYPE` and `OPENAI_API_KEY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for connecting to OpenAI-compatible AI providers.
  * Documented configuration examples for services including OpenRouter, LM Studio, vLLM, LiteLLM, llama.cpp, and Azure OpenAI.
  * Added troubleshooting advice and guidance on choosing between compatible services and the native Ollama provider.
  * Expanded environment-variable documentation and added navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->