### PR TITLE
fix(tags): never offer paperless-gpt's own tags to the LLM

### DIFF
--- a/app_llm.go
+++ b/app_llm.go
@@ -88,9 +88,7 @@ func (app *App) getSuggestedTags(
 	defer templateMutex.RUnlock()
 
 	// Remove all paperless-gpt related tags from available tags
-	availableTags = removeTagFromList(availableTags, manualTag)
-	availableTags = removeTagFromList(availableTags, autoTag)
-	availableTags = removeTagFromList(availableTags, autoOcrTag)
+	availableTags = removeSystemTags(availableTags)
 
 	// Get available tokens for content
 	templateData := map[string]interface{}{
@@ -174,7 +172,11 @@ func (app *App) getSuggestedTags(
 				}
 			}
 		}
-		return filteredTags, nil
+		// The original tags were merged in above, and on a document being
+		// processed those include the trigger tag paperless-gpt is reacting to.
+		// With CREATE_NEW_TAGS on, nothing else here would drop them, so a
+		// system tag would come back out as a "suggestion" and be re-applied.
+		return removeSystemTags(filteredTags), nil
 	}
 
 	filteredTags := []string{}
@@ -187,7 +189,10 @@ func (app *App) getSuggestedTags(
 		}
 	}
 
-	return filteredTags, nil
+	// Belt and braces: availableTags is already system-tag-free, so this only
+	// matters if that ever regresses. paperless-gpt applies its own tags
+	// through AddTags/RemoveTags, never through a suggestion.
+	return removeSystemTags(filteredTags), nil
 }
 
 // getSuggestedDocumentType generates a suggested document type for a document using the LLM
@@ -376,6 +381,7 @@ func (app *App) getSuggestedCreatedDate(ctx context.Context, content string, log
 	result := textsanitize.StripReasoning(completion.Choices[0].Content)
 	return strings.TrimSpace(strings.Trim(result, "\"")), nil
 }
+
 var xmlAttrEscaper = strings.NewReplacer(
 	"&", "&amp;",
 	`"`, "&quot;",
@@ -392,6 +398,7 @@ var xmlTextEscaper = strings.NewReplacer(
 
 func escapeXMLAttr(s string) string { return xmlAttrEscaper.Replace(s) }
 func escapeXMLText(s string) string { return xmlTextEscaper.Replace(s) }
+
 // getSuggestedCustomFields generates suggested custom fields for a document using the LLM
 func (app *App) getSuggestedCustomFields(ctx context.Context, doc Document, selectedFieldIDs []int, logger *logrus.Entry) ([]CustomFieldSuggestion, error) {
 	// Fetch all available custom fields

--- a/app_llm_test.go
+++ b/app_llm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -596,4 +597,88 @@ func findFieldByID(fields []CustomFieldSuggestion, id int) (CustomFieldSuggestio
 		}
 	}
 	return CustomFieldSuggestion{}, false
+}
+
+// TestGetSuggestedTags_SystemTagsNeverSuggested pins the tag-loop fix.
+//
+// paperless-gpt's own tags — the triggers it watches for and the markers it
+// writes — must never reach the LLM as candidates, and must never come back
+// out as suggestions. #877 shows why: with a paperless-ngx workflow chaining
+// OCR to tagging, one suggested `paperless-gpt-ocr-complete` re-triggers the
+// workflow, which re-adds the auto tag, which re-runs tagging, forever — and
+// every pass bills another round of LLM calls. #1015 reports the same leak for
+// FAIL_TAG and the completion tags.
+//
+// Two paths need covering, because they filter differently: with
+// CREATE_NEW_TAGS off, suggestions are intersected with the available list;
+// with it on, arbitrary suggestions are kept. The second path is the dangerous
+// one, since getSuggestedTags merges the document's original tags into its
+// suggestions — and on a document being processed those include the trigger
+// tag itself.
+func TestGetSuggestedTags_SystemTagsNeverSuggested(t *testing.T) {
+	systemTagNames := []string{
+		"paperless-gpt",               // MANUAL_TAG
+		"paperless-gpt-auto",          // AUTO_TAG
+		"paperless-gpt-ocr-auto",      // AUTO_OCR_TAG
+		"paperless-gpt-failed",        // FAIL_TAG
+		"paperless-gpt-auto-complete", // AUTO_TAG_COMPLETE
+		"paperless-gpt-ocr-complete",  // PDF_OCR_COMPLETE_TAG
+	}
+
+	for _, createNew := range []bool{false, true} {
+		name := "CREATE_NEW_TAGS off"
+		if createNew {
+			name = "CREATE_NEW_TAGS on"
+		}
+		t.Run(name, func(t *testing.T) {
+			previous := struct{ manual, auto, ocrAuto, fail, complete, ocrComplete string }{
+				manualTag, autoTag, autoOcrTag, failTag, autoTagComplete, pdfOCRCompleteTag,
+			}
+			manualTag, autoTag, autoOcrTag = "paperless-gpt", "paperless-gpt-auto", "paperless-gpt-ocr-auto"
+			failTag, autoTagComplete, pdfOCRCompleteTag = "paperless-gpt-failed", "paperless-gpt-auto-complete", "paperless-gpt-ocr-complete"
+			previousCreateNewTags := createNewTags
+			createNewTags = createNew
+			t.Cleanup(func() {
+				manualTag, autoTag, autoOcrTag = previous.manual, previous.auto, previous.ocrAuto
+				failTag, autoTagComplete, pdfOCRCompleteTag = previous.fail, previous.complete, previous.ocrComplete
+				createNewTags = previousCreateNewTags
+			})
+
+			previousTemplate := tagTemplate
+			tagTemplate = template.Must(template.New("tag").Parse(testTagTemplate))
+			t.Cleanup(func() { tagTemplate = previousTemplate })
+
+			// The model echoes back every system tag plus one real one — the
+			// worst case, and what actually happens when the system tags are
+			// visible in the prompt.
+			mockLLM := &mockLLM{Response: strings.Join(append(systemTagNames, "Invoice"), ",")}
+			app := &App{LLM: mockLLM}
+
+			// Available tags as paperless-ngx would report them: real tags and
+			// paperless-gpt's own, since they all live in the same namespace.
+			availableTags := append([]string{"Invoice", "Insurance"}, systemTagNames...)
+			// The document carries the trigger tag it is being processed under.
+			originalTags := []string{"Insurance", "paperless-gpt-auto"}
+
+			suggested, err := app.getSuggestedTags(
+				context.Background(), "Some document content", "A Title",
+				availableTags, originalTags, logrus.WithField("test", "system-tags"),
+			)
+			require.NoError(t, err)
+
+			for _, systemTag := range systemTagNames {
+				assert.NotContains(t, suggested, systemTag,
+					"system tag %q must never be suggested", systemTag)
+			}
+			// The real tags must still survive the filtering.
+			assert.Contains(t, suggested, "Invoice")
+			assert.Contains(t, suggested, "Insurance")
+
+			// And they must not have been offered to the model either.
+			for _, systemTag := range systemTagNames {
+				assert.NotContains(t, mockLLM.lastPrompt, systemTag,
+					"system tag %q must not appear in the prompt", systemTag)
+			}
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -891,6 +891,59 @@ func removeTagFromList(tags []string, tagToRemove string) []string {
 	return filteredTags
 }
 
+// systemTags returns every tag paperless-gpt manages itself: the triggers it
+// watches for and the markers it writes. None of them describe a document, so
+// none of them belong in a suggestion prompt.
+//
+// Configured-empty tags are skipped, because "" would otherwise match nothing
+// useful and only obscures intent.
+func systemTags() []string {
+	configured := []string{
+		manualTag,
+		autoTag,
+		autoOcrTag,
+		failTag,
+		autoTagComplete,
+		pdfOCRCompleteTag,
+	}
+	tags := make([]string, 0, len(configured))
+	for _, tag := range configured {
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	return tags
+}
+
+// removeSystemTags strips paperless-gpt's own tags from a list of tag names
+// before it reaches the LLM.
+//
+// Leaving any of them in has consequences beyond a cosmetically wrong
+// suggestion: the LLM offers the tag, paperless-gpt applies it, and the
+// document re-enters a processing queue. With a paperless-ngx workflow
+// chaining OCR to tagging, suggesting the OCR-complete tag produces an
+// unbounded loop that re-bills every LLM call on each pass (#877), and
+// suggesting the fail or completion tag makes a document lie about its own
+// state (#1015).
+//
+// Matching is case-insensitive: paperless-ngx tag names are case-preserving
+// but users routinely configure a different case than the tag actually has,
+// and a near-miss here reopens the loop.
+func removeSystemTags(tags []string) []string {
+	excluded := make(map[string]bool)
+	for _, tag := range systemTags() {
+		excluded[strings.ToLower(tag)] = true
+	}
+
+	filtered := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if !excluded[strings.ToLower(tag)] {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
 // getLikelyLanguage determines the likely language of the document content
 func getLikelyLanguage() string {
 	likelyLanguage := os.Getenv("LLM_LANGUAGE")
@@ -1259,7 +1312,6 @@ func createVisionLLM() (llms.Model, error) {
 		return nil, nil
 	}
 }
-
 
 func createCustomHTTPClient() *http.Client {
 	// Create custom transport that adds headers


### PR DESCRIPTION
> 🤖 **Automated fix** — written by Claude Code running in the maintainer's repo checkout and pushed under the maintainer's account, not hand-written by them. Verified locally: build clean, full Go suite green (286 tests), new tests fail on `main` without the fix.

Fixes #877 and #1015.

## The bug

`getSuggestedTags` filtered three of paperless-gpt's six own tags out of the candidate list:

```go
availableTags = removeTagFromList(availableTags, manualTag)
availableTags = removeTagFromList(availableTags, autoTag)
availableTags = removeTagFromList(availableTags, autoOcrTag)
```

`FAIL_TAG`, `AUTO_TAG_COMPLETE` and `PDF_OCR_COMPLETE_TAG` were missing, so the LLM saw them as ordinary document tags and suggested them. @fr0der1c's analysis in #877 was exactly right.

**This costs money.** With the OCR→tagging workflow from #877 (paperless-ngx workflow triggering on `paperless-gpt-ocr-complete` to assign `paperless-gpt-auto`), one suggested completion tag re-triggers the workflow, which re-adds the auto tag, which re-runs tagging, which suggests it again. Unbounded, and every pass bills another round of LLM calls. Two reporters confirmed it; one wrote their own replacement integration over it. #1015 reports the same leak for the fail and completion tags, where the damage is a document asserting a processing state it was never in.

## Second leak, same bug

Filtering the candidate list is not sufficient. `getSuggestedTags` merges the document's original tags into its suggestions:

```go
suggestedTags = append(suggestedTags, originalTags...)
```

On a document currently being processed, `originalTags` contains the trigger tag. With `CREATE_NEW_TAGS=true` the code then keeps every non-empty suggestion verbatim, so nothing downstream would have dropped it — fixing only the candidate list would have left that path broken and the loop intact for those users. The result is now filtered too.

## Changes

- `systemTags()` / `removeSystemTags()` in `main.go` replace the three hardcoded exclusions, covering all six tags (`MANUAL_TAG`, `AUTO_TAG`, `AUTO_OCR_TAG`, `FAIL_TAG`, `AUTO_TAG_COMPLETE`, `PDF_OCR_COMPLETE_TAG`). A tag added in future is covered by construction instead of by remembering to extend a list at the call site — which is how this bug happened in the first place.
- Matching is now **case-insensitive**. paperless-ngx tag names are case-preserving, but users routinely configure a different case than the tag actually carries, and a near-miss here silently reopens the loop.
- Empty-configured tags are skipped, so disabling a tag with `""` doesn't turn into a match-nothing entry.
- Applied to both the candidate list and the suggestion result.

## Tests

`TestGetSuggestedTags_SystemTagsNeverSuggested` runs both filtering paths (`CREATE_NEW_TAGS` off and on) with the model echoing back all six system tags plus a real one, and asserts they appear in neither the suggestions nor the prompt, while the real tags survive. Both subtests fail on `main`:

```
CREATE_NEW_TAGS off: ["Insurance" "Invoice" "paperless-gpt-auto-complete" "paperless-gpt-failed" ...]
CREATE_NEW_TAGS on:  ["Insurance" "Invoice" "paperless-gpt" "paperless-gpt-auto" ...]
```

## Related but deliberately not fixed here

That `append(suggestedTags, originalTags...)` line is also the cause of **#1054** — "tag suggestions can never remove a tag", because the original tags are merged back in before the replace logic runs. Whether tag suggestions should union with or replace the existing tags is a product decision with a real chance of surprising people who rely on the additive behaviour, so it is left alone rather than bundled into a loop fix.

Also worth noting: `PDF_OCR_COMPLETE_TAG` is not auto-created at startup the way `FAIL_TAG` is, which is a separate contributor to #854. #1059 addresses that for `AUTO_TAG_COMPLETE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - System-managed processing tags are now excluded from AI-generated tag suggestions.
  - Filtering applies both when creating new tags is enabled and when it is disabled.
  - User-defined tags remain available for suggestion.
  - Tag matching is case-insensitive, preventing system tags from reappearing under different capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->