### PR TITLE
fix(e2e): unbreak the mock E2E gate against paperless-ngx 3.x

### DIFF
--- a/web-app/e2e/test-environment.ts
+++ b/web-app/e2e/test-environment.ts
@@ -96,12 +96,13 @@ export async function setupTestEnvironment(config?: TestEnvironmentConfig): Prom
     started.push(postgres);
 
     console.log('Starting Paperless-ngx container...');
-    const paperlessNgx = await new GenericContainer('ghcr.io/paperless-ngx/paperless-ngx:latest')
+    const paperlessNgx = await new GenericContainer('ghcr.io/paperless-ngx/paperless-ngx:3.1.3@sha256:aa810a36942c63d4ee70d00eda7236cd3d6acfb7eb3f7987fb568ed14df8817a')
       .withNetwork(network)
       .withNetworkAliases('paperless-ngx')
       .withEnvironment({
         PAPERLESS_URL: `http://localhost:${paperlessPort}`,
-        PAPERLESS_SECRET_KEY: 'change-me',
+        // paperless-ngx rejects its documented placeholder as insecure.
+        PAPERLESS_SECRET_KEY: 'paperless-gpt-e2e-test-secret-key-4c6c1d2e',
         PAPERLESS_ADMIN_USER: 'admin',
         PAPERLESS_ADMIN_PASSWORD: 'admin',
         PAPERLESS_TIME_ZONE: 'Europe/Berlin',
@@ -220,6 +221,16 @@ export interface PaperlessDocument {
   tags: number[];
 }
 
+interface PaperlessTaskStatus {
+  id?: number;
+  related_document_ids?: number[];
+  result?: string;
+  result_data?: { document_id?: number };
+  status: string;
+}
+
+const maxSuccessfulTaskWithoutDocumentIDPolls = 5;
+
 // Helper to upload a document via Paperless-ngx API
 export async function uploadDocument(
   baseUrl: string,
@@ -248,6 +259,7 @@ export async function uploadDocument(
   }
   
   const task_id = await uploadResponse.json();
+  let successfulTaskWithoutDocumentIDPolls = 0;
   
   // Poll the tasks endpoint until document is processed
   while (true) {
@@ -262,19 +274,40 @@ export async function uploadDocument(
       throw new Error(`Failed to check task status: ${taskResponse.statusText}`);
     }
 
-    const taskResultArr = await taskResponse.json();
-    console.log(`Task status: ${JSON.stringify(taskResultArr)}`);
+    const taskResultPayload: unknown = await taskResponse.json();
+    let taskResultArr: PaperlessTaskStatus[];
+    if (Array.isArray(taskResultPayload)) {
+      taskResultArr = taskResultPayload as PaperlessTaskStatus[];
+    } else if (typeof taskResultPayload === 'object' && taskResultPayload !== null &&
+      Array.isArray((taskResultPayload as { results?: unknown }).results)) {
+      taskResultArr = (taskResultPayload as { results: PaperlessTaskStatus[] }).results;
+    } else {
+      throw new Error(`Unexpected task status response: ${JSON.stringify(taskResultPayload)}`);
+    }
+    console.log(`Task status: ${JSON.stringify(taskResultPayload)}`);
 
     if (taskResultArr.length === 0) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
       continue;
     }
     const taskResult = taskResultArr[0];
     // Check if task is completed
-    if (taskResult.status === 'SUCCESS' && taskResult.id) {
-      console.log(`Document processed successfully with ID: ${taskResult.id}`);
+    if (taskResult.status.toUpperCase() === 'SUCCESS') {
+      const documentId = taskResult.result_data?.document_id ?? taskResult.related_document_ids?.[0];
+      if (!documentId) {
+        successfulTaskWithoutDocumentIDPolls++;
+        if (successfulTaskWithoutDocumentIDPolls >= maxSuccessfulTaskWithoutDocumentIDPolls) {
+          throw new Error(
+            `Document processing reported SUCCESS without a document ID after ${successfulTaskWithoutDocumentIDPolls} polls: ${JSON.stringify(taskResultPayload)}`
+          );
+        }
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        continue;
+      }
+      console.log(`Document processed successfully with ID: ${documentId}`);
       
       // Fetch the complete document details
-      const documentResponse = await fetch(`${baseUrl}/api/documents/${taskResult.id}/`, {
+      const documentResponse = await fetch(`${baseUrl}/api/documents/${documentId}/`, {
         headers: {
           'Authorization': 'Basic ' + btoa(`${credentials.username}:${credentials.password}`),
         },
@@ -288,9 +321,11 @@ export async function uploadDocument(
     }
     
     // Check for failure
-    if (taskResult.status === 'FAILED') {
+    if (taskResult.status.toUpperCase() === 'FAILED') {
       throw new Error(`Document processing failed: ${taskResult.result}`);
     }
+
+    successfulTaskWithoutDocumentIDPolls = 0;
     
     // Wait before polling again
     await new Promise(resolve => setTimeout(resolve, 1000));


### PR DESCRIPTION
> 🤖 **Automated fix** — assembled by Claude Code running in the maintainer's repo checkout and pushed under the maintainer's account, not hand-written by them. The code changes are @lunetics' work from #1058, extracted so CI recovers independently.

**This should go in before anything else** — the required `E2E Tests (Mock LLM)` check is currently failing on *every* open PR, so nothing can go green on its own merit.

## Symptom

The check fails during environment setup, before any assertion runs:

```
s6-rc: warning: unable to start service init-migrations: command exited 1
/run/s6/basedir/scripts/rc.init: warning: s6-rc failed to properly bring all the services up!
Failed to set up test environment, cleaning up already-started resources:
  Error: URL /api/ not accessible after 60000ms
```

Three retries, three identical failures (see run 34428680514 on #749, and the same on #876 and #835).

## Root cause, confirmed empirically

paperless-ngx 3.x refuses to start when `PAPERLESS_SECRET_KEY` is unset **or still the documented `change-me` placeholder** — which is exactly what `test-environment.ts` passed. Reproduced directly against the image:

```
$ docker run --rm -e PAPERLESS_SECRET_KEY=change-me \
    ghcr.io/paperless-ngx/paperless-ngx:3.1.3 python3 -c "...django.setup()"

django.core.exceptions.ImproperlyConfigured: PAPERLESS_SECRET_KEY is not set or is
the default 'change-me' value. A unique, secret key is required for secure operation.
s6-rc: warning: unable to start service init-migrations: command exited 1
/run/s6/basedir/scripts/rc.init: warning: s6-rc failed to properly bring all the services up!
```

Identical signature to CI. With a real key it gets past that gate and proceeds to `[init-migrations] Apply database migrations...` as expected.

The container therefore dies during init, `/api/` never answers, and the 60s wait times out. Because the test environment tracked `:latest`, this broke with no change on our side — and would silently break again on the next upstream release.

## Changes

- **Pin paperless-ngx to `3.1.3` by digest** rather than `:latest`. A test environment that follows a moving upstream tag isn't a test environment.
- **Use a secret key paperless-ngx accepts.**
- **Handle the 3.x task API.** The document id now arrives as `result_data.document_id` or `related_document_ids[0]`, not as the task's own `id`; status is compared case-insensitively. A `SUCCESS` task without a document id is retried a bounded number of times instead of being trusted immediately (previously it would have fetched `/api/documents/undefined/`).
- **Add the missing sleep to the empty-`results` branch** of the upload poll. That `continue` had no delay, so the loop hammered the tasks endpoint as fast as it could — plausibly contributing to the startup contention.

## Scope

Test-infrastructure only; no application code touched. Deliberately excludes #1058's new `test-environment.spec.ts` and the `package.json` change that runs it, to keep this to the minimum needed to get CI green — those stay with #1058.

Credit for the actual fix is @lunetics'; it was buried in a 2000-line feature PR where its repo-wide value wasn't obvious.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved document upload processing reliability across supported task response formats.
  - More accurately detects successful and failed processing states.
  - Reports an explicit error when processing succeeds but no document ID is returned.

- **Chores**
  - Standardized the test environment by pinning the Paperless-ngx container version and using a consistent test secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->