### PR TITLE
style: gofmt the content-logging branch from #922

### DIFF
--- a/paperless.go
+++ b/paperless.go
@@ -915,10 +915,10 @@ func (client *PaperlessClient) UpdateDocuments(ctx context.Context, documents []
 				}
 			}
 			if field == "content" {
-			log.Debugf("Document %d: Updated %s from %v to %v", documentID, field, value, updatedFields[field])
-		} else {
-			log.Printf("Document %d: Updated %s from %v to %v", documentID, field, value, updatedFields[field])
-		}
+				log.Debugf("Document %d: Updated %s from %v to %v", documentID, field, value, updatedFields[field])
+			} else {
+				log.Printf("Document %d: Updated %s from %v to %v", documentID, field, value, updatedFields[field])
+			}
 			mod := ModificationHistory{
 				DocumentID:    uint(documentID),
 				ModField:      field,


### PR DESCRIPTION
> 🤖 **Automated change** — written by Claude Code running in the maintainer's repo checkout and pushed under the maintainer's account, not hand-written by them.

Follow-up to #922. The added `if field == "content"` block was indented one level short, so `gofmt -l .` flagged `paperless.go` — which is what had turned `build-amd64` red on that PR before it was updated.

The change itself was correct (full document content at info level is a privacy problem: it lands in `docker logs` and any log shipper, and `content` is the one field whose before/after values are the entire document). Only the formatting needed fixing, and a two-line whitespace correction wasn't worth bouncing back to the contributor.

Whitespace only. Full Go suite green (375 tests); `gofmt -d paperless.go` now clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Content field updates are now recorded at debug level, reducing routine log noise.
  - Updates to other fields continue to appear in the standard informational logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->