### PR TITLE
ci: build the GHCR manifest from GHCR, not Docker Hub

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -269,9 +269,16 @@ jobs:
             docker buildx imagetools create -t ${DOCKERHUB_REPO}:${VERSION} \
               ${DOCKERHUB_REPO}@sha256:${AMD64_DIGEST} ${DOCKERHUB_REPO}@sha256:${ARM64_DIGEST}
 
-            # Create manifests for GHCR
+            # Create manifests for GHCR. Sourced from the GHCR copies, not
+            # Docker Hub: build-amd64/build-arm64 push the identical image to
+            # both registries in one buildx invocation, so the digests match,
+            # and assembling from Docker Hub would make every push copy both
+            # architecture blobs across registries — burning Docker Hub pull
+            # quota for nothing. A batch of merges reliably hits
+            # "toomanyrequests: You have reached your unauthenticated pull
+            # rate limit" and the publish fails.
             docker buildx imagetools create -t ${GHCR_REPO}:${VERSION} \
-              ${DOCKERHUB_REPO}@sha256:${AMD64_DIGEST} ${DOCKERHUB_REPO}@sha256:${ARM64_DIGEST}
+              ${GHCR_REPO}@sha256:${AMD64_DIGEST} ${GHCR_REPO}@sha256:${ARM64_DIGEST}
 
             # Also push "latest" tag when on a tag
             if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
@@ -279,9 +286,9 @@ jobs:
               docker buildx imagetools create -t ${DOCKERHUB_REPO}:latest \
                 ${DOCKERHUB_REPO}@sha256:${AMD64_DIGEST} ${DOCKERHUB_REPO}@sha256:${ARM64_DIGEST}
 
-              # GHCR latest
+              # GHCR latest — same reasoning as above.
               docker buildx imagetools create -t ${GHCR_REPO}:latest \
-                ${DOCKERHUB_REPO}@sha256:${AMD64_DIGEST} ${DOCKERHUB_REPO}@sha256:${ARM64_DIGEST}
+                ${GHCR_REPO}@sha256:${AMD64_DIGEST} ${GHCR_REPO}@sha256:${ARM64_DIGEST}
             fi
           fi
       - name: Inspect manifest


### PR DESCRIPTION
> 🤖 **Automated fix** — written by Claude Code running in the maintainer's repo checkout and pushed under the maintainer's account, not hand-written by them.

Fixes the `merge-manifests` failure that blocked publishing after today's merge batch.

## The bug

`merge-manifests` assembled the **GHCR** manifest list out of **Docker Hub** source digests:

```bash
docker buildx imagetools create -t ${GHCR_REPO}:${VERSION} \
  ${DOCKERHUB_REPO}@sha256:${AMD64_DIGEST} ${DOCKERHUB_REPO}@sha256:${ARM64_DIGEST}
```

But `build-amd64` and `build-arm64` already push the identical image to **both** registries in one buildx invocation:

```bash
TAGS=${DOCKERHUB_REPO}:unreleased-amd64,${GHCR_REPO}:unreleased-amd64
```

Images are content-addressed, so the digest is the same in each registry. Sourcing from Docker Hub therefore made every push to `main` copy both architecture blobs across registries to produce something already sitting in GHCR — spending Docker Hub pull quota for nothing.

## It doesn't just waste quota, it fails

Merging today's batch produced eight pushes to `main` in five minutes. The last one died:

```
toomanyrequests: You have reached your unauthenticated pull rate limit
ERROR: copy sha256:3956... from docker.io/.../paperless-gpt@sha256:8509...
       to ghcr.io/.../paperless-gpt:unreleased: 429 Too Many Requests
```

A re-run hit it again, so it isn't transient flakiness within one run.

## Verified, not assumed

The content the job was pulling from Docker Hub is already in GHCR under the same digest:

```
$ docker buildx imagetools inspect ghcr.io/icereed/paperless-gpt:unreleased-amd64
Digest: sha256:85099a287e5f6bc72b7a71030e1118eb2a5b9100cb286b6b9e73f680efb48e01
```

That is exactly the digest in the failing log line above. The cross-registry copy was pure overhead.

The **fork** branch of this same script already used `${GHCR_REPO}@sha256:...`; this only makes the main-repo branch consistent with it.

## Scope

- GHCR manifest for `${VERSION}` → sourced from GHCR.
- GHCR `latest` (tag builds) → same.
- **Docker Hub manifest unchanged** — assembled from Docker Hub digests, which is same-registry and doesn't copy blobs.

YAML validated; no job names or dependencies changed, so the required-check contexts are unaffected.

## What this does *not* fix

Two things are still outstanding and are not code problems:

1. **The current rate-limit window has to expire.** Even the lightweight Docker Hub `HEAD` requests in the Docker Hub manifest step are 429ing right now — my own local `imagetools inspect` against Docker Hub got 429 too. This change removes the blob copying, which is the bulk of the consumption, but doesn't insulate the job from Docker Hub entirely. Worth a follow-up look at whether `imagetools` is actually using the `docker/login-action` credentials, since the error says *unauthenticated* despite the login step passing.
2. **`E2E Tests (Registry Image)` is red for an unrelated reason:** `429: You have no credits remaining` from OpenAI. That gate has been failing since before today's merges — the first main run of the batch already reported it — and needs credits topped up, not a code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GHCR manifest creation to use GHCR image digests for versioned and `latest` tags.
  - Docker Hub manifest creation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->