### PR TITLE
ci(renovate): stop rebasing every open PR on every push to main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   ],
   "automerge": true,
   "automergeType": "pr",
+  "rebaseWhen": "conflicted",
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
> 🤖 **Automated fix** — written by Claude Code running in the maintainer's repo checkout and pushed under the maintainer's account, not hand-written by them. **Deliberately not merged** — see "Why this is not merged" below.

Explains and mitigates why `main` went red today after a batch of merges.

## What happened

Merging 16 PRs produced eight pushes to `main` in five minutes. `config:recommended` defaults to `rebaseWhen: "auto"`, which rebases **every open Renovate PR** whenever `main` moves. With ten open Renovate PRs, that fanned out into **30 Renovate pipelines — 30 of the 35 Docker-building runs for the day**:

```
$ gh api ".../actions/runs?created=2026-09-10" --jq '... group_by(renovate) ...'
[{"count":5,"renovate":false},{"count":30,"renovate":true}]
```

Each of those runs `test` + `build-amd64` + `build-arm64` + `e2e-mock`, and each Docker build pulls `golang`, `node` and `alpine` from Docker Hub. That exhausted the pull quota, which then broke the builds on `main` itself:

```
ERROR: failed to solve: docker.io/alpine:3.23.0: failed to resolve source metadata
for docker.io/library/alpine:3.23.0: 429 Too Many Requests
ERROR: failed to solve: docker.io/node:24-alpine: ... 429 Too Many Requests
```

Note the "Log in to Docker Hub" step **succeeded** in those jobs — so this is genuine quota exhaustion, not an authentication failure.

## The backlog is a symptom, not the cause

`automerge: true` is set, so these PRs were supposed to land on their own. They never could: the repository ruleset still requires status checks that no longer run on pull requests —

- `merge-manifests`, which is gated `if: github.event_name != 'pull_request'` and so is always skipped on a PR, and
- `Build and Push Docker Images / E2E Tests (Local Build) (pull_request)`, a job renamed to **E2E Tests (Mock LLM)** during the CI rework, so that check never appears at all.

So no Renovate PR could ever satisfy its required checks, nothing automerged, and PRs accumulated. The oldest one still open (#180) is from **February 2025**.

## This change

- `rebaseWhen: "conflicted"` — rebase only PRs that actually need it. This is the fix for the fan-out.
- `prConcurrentLimit: 3` / `prHourlyLimit: 2` — cap the backlog so it can't silently grow back to ten.

## Why this is not merged

Merging it means another push to `main`, which right now would trigger another round of Docker Hub pulls that will fail on the same 429 — adding a red run without accomplishing anything. The quota window needs to roll over first.

More importantly, **this PR treats the symptom.** The keystone fix is the ruleset, and that requires the repository settings change I could not make (three attempts, each refused by the sandbox):

> Required status checks should be: `test`, `build-amd64`, `build-arm64`, `E2E Tests (Mock LLM)`.

With that corrected, Renovate's automerge starts working, the backlog drains on its own, and the fan-out problem largely disappears even without this change. Both together are better than either alone.

## Also relevant

#1068 (already merged) removes the other Docker Hub consumer: `merge-manifests` was assembling the GHCR manifest from Docker Hub digests, copying both architecture blobs across registries on every push to produce something already present in GHCR.

Neither change addresses base-image pulls, which are inherently Docker Hub traffic. If this recurs after the ruleset is fixed, the next step would be mirroring the base images or pinning them by digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update scheduling to limit pull requests to two per hour and three concurrently.
  * Configured updates to be rebased when conflicts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->